### PR TITLE
ci: add PR e2e-smoke job and smoke script; tag scroll progress test as @smoke

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
     concurrency:
       group: e2e-smoke-${{ github.ref }}
       cancel-in-progress: true
@@ -41,14 +44,23 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
       - name: Run E2E Smoke (Chromium)
         run: npm run test:e2e:smoke -- --reporter=github
+      - name: Upload smoke report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-smoke
+          path: web/playwright-report
 
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read
     concurrency:
       group: e2e-${{ github.ref }}
       cancel-in-progress: true
@@ -83,8 +95,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-playwright-
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
 
       - name: Run E2E (Chromium)
         if: github.event_name == 'push'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,45 @@ on:
       - main
 
 jobs:
+  e2e-smoke:
+    name: E2E Smoke (PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: e2e-smoke-${{ github.ref }}
+      cancel-in-progress: true
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Setup npm cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Install deps
+        run: npm ci --no-audit --no-fund
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run E2E Smoke (Chromium)
+        run: npm run test:e2e:smoke -- --reporter=github
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -48,6 +87,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run E2E (Chromium)
+        if: github.event_name == 'push'
         run: npm run test:e2e -- --reporter=github
 
       - name: Upload report on failure

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "email": "email dev --dir emails --port 3001",
     "start:test": "next build && next start -p 3000",
     "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test --grep @smoke",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "email": "email dev --dir emails --port 3001",
     "start:test": "next build && next start -p 3000",
     "test:e2e": "playwright test",
-    "test:e2e:smoke": "playwright test --grep @smoke",
+    "test:e2e:smoke": "playwright test --grep \"@smoke\"",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report"
   },

--- a/web/tests/e2e/scroll-progress.spec.ts
+++ b/web/tests/e2e/scroll-progress.spec.ts
@@ -12,28 +12,25 @@ test.describe('Scroll progress indicator', () => {
     })
   })
 
+  // Helper inside Node context is not callable from page context; we centralize via a single evaluate wrapper below
+
   test('grows with scroll @smoke', async ({ page }) => {
     const bar = page.getByTestId('scroll-progress')
     await expect(bar).toBeAttached()
     // Don't assert visibility; at scaleX=0 the element may be effectively hidden.
 
-    const getScaleX = (transform: string | null) => {
-      if (!transform || transform === 'none') return 0
-      // matrix(a, b, c, d, e, f) => a is scaleX
-      const match = transform.match(/matrix\(([^,]+)/)
-      if (!match) return 0
-      const a = parseFloat(match[1])
-      return isNaN(a) ? 0 : a
+    const readScale = async () => {
+      return await bar.evaluate(el => {
+        const t = getComputedStyle(el).transform
+        if (!t || t === 'none') return 0
+        const m = t.match(/matrix\(([^,]+)/)
+        if (!m) return 0
+        const a = parseFloat(m[1]!)
+        return isNaN(a) ? 0 : a
+      })
     }
 
-    const initialScale = await bar.evaluate(el => {
-      const t = getComputedStyle(el).transform
-      if (!t || t === 'none') return 0
-      const m = t.match(/matrix\(([^,]+)/)
-      if (!m) return 0
-      const a = parseFloat(m[1]!)
-      return isNaN(a) ? 0 : a
-    })
+    const initialScale = await readScale()
 
     await page.evaluate(() => {
       const doc = document.documentElement
@@ -45,14 +42,7 @@ test.describe('Scroll progress indicator', () => {
     let currentScale = initialScale
     while (Date.now() - start < 2000 && currentScale <= initialScale + 0.2) {
       await page.waitForTimeout(50)
-      currentScale = await bar.evaluate(el => {
-        const t = getComputedStyle(el).transform
-        if (!t || t === 'none') return 0
-        const m = t.match(/matrix\(([^,]+)/)
-        if (!m) return 0
-        const a = parseFloat(m[1]!)
-        return isNaN(a) ? 0 : a
-      })
+      currentScale = await readScale()
     }
 
     // Require a meaningful increase to avoid noise
@@ -68,14 +58,7 @@ test.describe('Scroll progress indicator', () => {
     let bottomScale = currentScale
     while (Date.now() - startBottom < 2000 && bottomScale < 0.95) {
       await page.waitForTimeout(50)
-      bottomScale = await bar.evaluate(el => {
-        const t = getComputedStyle(el).transform
-        if (!t || t === 'none') return 0
-        const m = t.match(/matrix\(([^,]+)/)
-        if (!m) return 0
-        const a = parseFloat(m[1]!)
-        return isNaN(a) ? 0 : a
-      })
+      bottomScale = await readScale()
     }
 
     expect(bottomScale).toBeGreaterThanOrEqual(0.95)

--- a/web/tests/e2e/scroll-progress.spec.ts
+++ b/web/tests/e2e/scroll-progress.spec.ts
@@ -12,7 +12,7 @@ test.describe('Scroll progress indicator', () => {
     })
   })
 
-  test('grows with scroll', async ({ page }) => {
+  test('grows with scroll @smoke', async ({ page }) => {
     const bar = page.getByTestId('scroll-progress')
     await expect(bar).toBeAttached()
     // Don't assert visibility; at scaleX=0 the element may be effectively hidden.


### PR DESCRIPTION
- Add e2e-smoke GitHub Action for PRs 
- Keep full e2e on push to main
- Add npm script test:e2e:smoke
- Tag scroll progress test as @smoke

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a smoke end-to-end test suite that runs automatically on pull requests.
  * Added a new npm script to run smoke tests using Playwright.
* **Tests**
  * Tagged an existing end-to-end test as a smoke test for targeted execution.
* **Chores**
  * Updated workflow to run full end-to-end tests only on push events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->