### PR TITLE
feat(cta): add mobile bottom CTA bar (tel + Get Quote) + e2e; bump Next 15.5.

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,8 +3,7 @@ import { Inter } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react';
 import { ScrollProgress } from "../components/ScrollProgress";
 import StickyContactBar from "../components/StickyContactBar";
-import dynamic from "next/dynamic";
-const MobileCtaBar = dynamic(() => import("../components/MobileCtaBar"), { ssr: false });
+import MobileCtaBar from "../components/MobileCtaBar";
 import "./globals.css";
 
 const inter = Inter({ subsets: ['latin'] })
@@ -17,6 +16,12 @@ export const metadata: Metadata = {
     shortcut: '/logo.ico',
     apple: '/logo.png',
   },
+};
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover' as const,
 };
 
 export default function RootLayout({

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,8 @@ import { Inter } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/react';
 import { ScrollProgress } from "../components/ScrollProgress";
 import StickyContactBar from "../components/StickyContactBar";
+import dynamic from "next/dynamic";
+const MobileCtaBar = dynamic(() => import("../components/MobileCtaBar"), { ssr: false });
 import "./globals.css";
 
 const inter = Inter({ subsets: ['latin'] })
@@ -28,6 +30,7 @@ export default function RootLayout({
         <ScrollProgress />
         {children}
         <StickyContactBar />
+        <MobileCtaBar />
         <Analytics />
       </body>
     </html>

--- a/web/components/MobileCtaBar.tsx
+++ b/web/components/MobileCtaBar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useCallback } from "react";
+import { CONTACT_INFO } from "@/config/contact";
+
+export default function MobileCtaBar() {
+  const handleGetQuote = useCallback((e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const contactSection = document.getElementById("contact");
+    if (contactSection) {
+      try {
+        contactSection.scrollIntoView({ behavior: "smooth", block: "start" });
+      } catch {
+        contactSection.scrollIntoView();
+      }
+    }
+    // Focus the first field on the quote/contact form
+    const firstField = document.getElementById("name") as HTMLInputElement | null;
+    if (firstField) {
+      // Delay slightly to allow scroll to settle on mobile browsers
+      window.setTimeout(() => {
+        firstField.focus({ preventScroll: true });
+      }, 250);
+    }
+    // If the anchor was provided, update the hash for deep-linking/back nav
+    if (window.location.hash !== "#contact") {
+      history.replaceState(null, "", "#contact");
+    }
+  }, []);
+
+  return (
+    <div
+      className="md:hidden fixed bottom-0 inset-x-0 z-[50] bg-slate-900/95 backdrop-blur border-t border-slate-700/60"
+    >
+      <div
+        className="px-4 pt-2 pb-2 pb-[max(env(safe-area-inset-bottom),12px)]"
+      >
+        <div className="max-w-screen-md mx-auto flex items-center gap-3">
+          <a
+            href={`tel:${CONTACT_INFO.phoneE164}`}
+            className="flex-1 inline-flex items-center justify-center h-12 min-h-[44px] rounded-lg bg-blue-600 text-white font-semibold shadow-sm hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 transition-colors"
+          >
+            Call
+          </a>
+          <a
+            href="#contact"
+            onClick={handleGetQuote}
+            className="flex-1 inline-flex items-center justify-center h-12 min-h-[44px] rounded-lg bg-amber-500 text-slate-900 font-semibold shadow-sm hover:bg-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 transition-colors"
+          >
+            Get Quote
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,7 @@
         "framer-motion": "12.23.12",
         "gsap": "^3.13.0",
         "lucide-react": "0.539.0",
-        "next": "15.4.6",
+        "next": "^15.5.2",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-email": "4.2.8",
@@ -28,7 +28,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "15.4.6",
+        "eslint-config-next": "^15.5.2",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -1351,15 +1351,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.6.tgz",
-      "integrity": "sha512-yHDKVTcHrZy/8TWhj0B23ylKv5ypocuCwey9ZqPyv4rPdUdRzpGCkSi03t04KBPyU96kxVtUqx6O3nE1kpxASQ==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.2.tgz",
+      "integrity": "sha512-Qe06ew4zt12LeO6N7j8/nULSOe3fMXE4dM6xgpBQNvdzyK1sv5y4oAP3bq4LamrvGCZtmRYnW8URFCeX5nFgGg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.4.6.tgz",
-      "integrity": "sha512-2NOu3ln+BTcpnbIDuxx6MNq+pRrCyey4WSXGaJIyt0D2TYicHeO9QrUENNjcf673n3B1s7hsiV5xBYRCK1Q8kA==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.2.tgz",
+      "integrity": "sha512-lkLrRVxcftuOsJNhWatf1P2hNVfh98k/omQHrCEPPriUypR6RcS13IvLdIrEvkm9AH2Nu2YpR5vLqBuy6twH3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1367,9 +1367,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.6.tgz",
-      "integrity": "sha512-667R0RTP4DwxzmrqTs4Lr5dcEda9OxuZsVFsjVtxVMVhzSpo6nLclXejJVfQo2/g7/Z9qF3ETDmN3h65mTjpTQ==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.2.tgz",
+      "integrity": "sha512-8bGt577BXGSd4iqFygmzIfTYizHb0LGWqH+qgIF/2EDxS5JsSdERJKA8WgwDyNBZgTIIA4D8qUtoQHmxIIquoQ==",
       "cpu": [
         "arm64"
       ],
@@ -1383,9 +1383,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.6.tgz",
-      "integrity": "sha512-KMSFoistFkaiQYVQQnaU9MPWtp/3m0kn2Xed1Ces5ll+ag1+rlac20sxG+MqhH2qYWX1O2GFOATQXEyxKiIscg==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.2.tgz",
+      "integrity": "sha512-2DjnmR6JHK4X+dgTXt5/sOCu/7yPtqpYt8s8hLkHFK3MGkka2snTv3yRMdHvuRtJVkPwCGsvBSwmoQCHatauFQ==",
       "cpu": [
         "x64"
       ],
@@ -1399,9 +1399,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.6.tgz",
-      "integrity": "sha512-PnOx1YdO0W7m/HWFeYd2A6JtBO8O8Eb9h6nfJia2Dw1sRHoHpNf6lN1U4GKFRzRDBi9Nq2GrHk9PF3Vmwf7XVw==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.2.tgz",
+      "integrity": "sha512-3j7SWDBS2Wov/L9q0mFJtEvQ5miIqfO4l7d2m9Mo06ddsgUK8gWfHGgbjdFlCp2Ek7MmMQZSxpGFqcC8zGh2AA==",
       "cpu": [
         "arm64"
       ],
@@ -1415,9 +1415,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.6.tgz",
-      "integrity": "sha512-XBbuQddtY1p5FGPc2naMO0kqs4YYtLYK/8aPausI5lyOjr4J77KTG9mtlU4P3NwkLI1+OjsPzKVvSJdMs3cFaw==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.2.tgz",
+      "integrity": "sha512-s6N8k8dF9YGc5T01UPQ08yxsK6fUow5gG1/axWc1HVVBYQBgOjca4oUZF7s4p+kwhkB1bDSGR8QznWrFZ/Rt5g==",
       "cpu": [
         "arm64"
       ],
@@ -1431,9 +1431,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.6.tgz",
-      "integrity": "sha512-+WTeK7Qdw82ez3U9JgD+igBAP75gqZ1vbK6R8PlEEuY0OIe5FuYXA4aTjL811kWPf7hNeslD4hHK2WoM9W0IgA==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.2.tgz",
+      "integrity": "sha512-o1RV/KOODQh6dM6ZRJGZbc+MOAHww33Vbs5JC9Mp1gDk8cpEO+cYC/l7rweiEalkSm5/1WGa4zY7xrNwObN4+Q==",
       "cpu": [
         "x64"
       ],
@@ -1447,9 +1447,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.6.tgz",
-      "integrity": "sha512-XP824mCbgQsK20jlXKrUpZoh/iO3vUWhMpxCz8oYeagoiZ4V0TQiKy0ASji1KK6IAe3DYGfj5RfKP6+L2020OQ==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.2.tgz",
+      "integrity": "sha512-/VUnh7w8RElYZ0IV83nUcP/J4KJ6LLYliiBIri3p3aW2giF+PAVgZb6mk8jbQSB3WlTai8gEmCAr7kptFa1H6g==",
       "cpu": [
         "x64"
       ],
@@ -1463,9 +1463,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.6.tgz",
-      "integrity": "sha512-FxrsenhUz0LbgRkNWx6FRRJIPe/MI1JRA4W4EPd5leXO00AZ6YU8v5vfx4MDXTvN77lM/EqsE3+6d2CIeF5NYg==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.2.tgz",
+      "integrity": "sha512-sMPyTvRcNKXseNQ/7qRfVRLa0VhR0esmQ29DD6pqvG71+JdVnESJaHPA8t7bc67KD5spP3+DOCNLhqlEI2ZgQg==",
       "cpu": [
         "arm64"
       ],
@@ -1479,9 +1479,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.6.tgz",
-      "integrity": "sha512-T4ufqnZ4u88ZheczkBTtOF+eKaM14V8kbjud/XrAakoM5DKQWjW09vD6B9fsdsWS2T7D5EY31hRHdta7QKWOng==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.2.tgz",
+      "integrity": "sha512-W5VvyZHnxG/2ukhZF/9Ikdra5fdNftxI6ybeVKYvBPDtyx7x4jPPSNduUkfH5fo3zG0JQ0bPxgy41af2JX5D4Q==",
       "cpu": [
         "x64"
       ],
@@ -4085,13 +4085,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.4.6.tgz",
-      "integrity": "sha512-4uznvw5DlTTjrZgYZjMciSdDDMO2SWIuQgUNaFyC2O3Zw3Z91XeIejeVa439yRq2CnJb/KEvE4U2AeN/66FpUA==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.2.tgz",
+      "integrity": "sha512-3hPZghsLupMxxZ2ggjIIrat/bPniM2yRpsVPVM40rp8ZMzKWOJp2CGWn7+EzoV2ddkUr5fxNfHpF+wU1hGt/3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.4.6",
+        "@next/eslint-plugin-next": "15.5.2",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -6254,12 +6254,12 @@
       }
     },
     "node_modules/next": {
-      "version": "15.4.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.6.tgz",
-      "integrity": "sha512-us++E/Q80/8+UekzB3SAGs71AlLDsadpFMXVNM/uQ0BMwsh9m3mr0UNQIfjKed8vpWXsASe+Qifrnu1oLIcKEQ==",
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.2.tgz",
+      "integrity": "sha512-H8Otr7abj1glFhbGnvUt3gz++0AF1+QoCXEBmd/6aKbfdFwrn0LpA836Ed5+00va/7HQSDD+mOoVhn3tNy3e/Q==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.6",
+        "@next/env": "15.5.2",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -6272,14 +6272,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.6",
-        "@next/swc-darwin-x64": "15.4.6",
-        "@next/swc-linux-arm64-gnu": "15.4.6",
-        "@next/swc-linux-arm64-musl": "15.4.6",
-        "@next/swc-linux-x64-gnu": "15.4.6",
-        "@next/swc-linux-x64-musl": "15.4.6",
-        "@next/swc-win32-arm64-msvc": "15.4.6",
-        "@next/swc-win32-x64-msvc": "15.4.6",
+        "@next/swc-darwin-arm64": "15.5.2",
+        "@next/swc-darwin-x64": "15.5.2",
+        "@next/swc-linux-arm64-gnu": "15.5.2",
+        "@next/swc-linux-arm64-musl": "15.5.2",
+        "@next/swc-linux-x64-gnu": "15.5.2",
+        "@next/swc-linux-x64-musl": "15.5.2",
+        "@next/swc-win32-arm64-msvc": "15.5.2",
+        "@next/swc-win32-x64-msvc": "15.5.2",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,7 @@
     "framer-motion": "12.23.12",
     "gsap": "^3.13.0",
     "lucide-react": "0.539.0",
-    "next": "15.4.6",
+    "next": "^15.5.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-email": "4.2.8",
@@ -29,13 +29,13 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.54.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.4.6",
-    "@playwright/test": "^1.54.2",
+    "eslint-config-next": "^15.5.2",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/web/tests/e2e/mobile-cta-bar.spec.ts
+++ b/web/tests/e2e/mobile-cta-bar.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, devices, Page } from '@playwright/test'
+
+test.use({ ...devices['iPhone 12'] })
+
+test.describe('Mobile CTA Bar', () => {
+	async function ensureMobile(page: Page) {
+		await page.emulateMedia({ reducedMotion: 'reduce' })
+		await page.addStyleTag({ content: 'html { scroll-behavior: auto !important; }' })
+	}
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/')
+		await page.waitForLoadState('domcontentloaded')
+		await ensureMobile(page)
+	})
+
+	test('renders on mobile view and shows buttons', async ({ page }) => {
+		const bar = page.getByRole('link', { name: 'Get Quote' })
+		await expect(bar).toBeVisible()
+		const call = page.getByRole('link', { name: 'Call' })
+		await expect(call).toBeVisible()
+	})
+
+	test('tel link opens dialer scheme', async ({ page }) => {
+		const call = page.getByRole('link', { name: 'Call' })
+		await expect(call).toHaveAttribute('href', /tel:\+447?123456789/) // E.164 number present
+	})
+
+	test('Get Quote scrolls to #contact and focuses first field', async ({ page }) => {
+		const getQuote = page.getByRole('link', { name: 'Get Quote' })
+		await getQuote.click()
+		// Wait a tick for focus to move
+		const nameInput = page.locator('#name')
+		await expect(nameInput).toBeFocused()
+		// Hash should be #contact
+		await expect(page).toHaveURL(/#contact$/)
+	})
+
+	test('buttons are at least 44px tall', async ({ page }) => {
+		const getQuote = page.getByRole('link', { name: 'Get Quote' })
+		const box = await getQuote.boundingBox()
+		expect(box?.height || 0).toBeGreaterThanOrEqual(44)
+		const call = page.getByRole('link', { name: 'Call' })
+		const box2 = await call.boundingBox()
+		expect(box2?.height || 0).toBeGreaterThanOrEqual(44)
+	})
+
+	test('visible focus rings on keyboard focus', async ({ page }) => {
+		// Move focus into document then tab to CTA links
+		await page.focus('body')
+		const call = page.getByRole('link', { name: 'Call' })
+		await call.focus()
+		await page.keyboard.press('Tab')
+		const getQuote = page.getByRole('link', { name: 'Get Quote' })
+		await expect(getQuote).toBeFocused()
+		// Tailwind ring utilities apply via box-shadow when :focus-visible
+		const styles = await getQuote.evaluate(el => {
+			const cs = getComputedStyle(el)
+			return { outlineWidth: cs.outlineWidth, boxShadow: cs.boxShadow }
+		})
+		const outline = parseFloat((styles.outlineWidth || '0').toString())
+		const hasShadow = !!styles.boxShadow && styles.boxShadow !== 'none'
+		expect(outline > 0 || hasShadow).toBeTruthy()
+	})
+
+	test('respects safe-area bottom padding', async ({ page }) => {
+		// Check arbitrary property is applied on the inner padding container (two levels up from link)
+		const getQuote = page.getByRole('link', { name: 'Get Quote' })
+		const barContainer = getQuote.locator('xpath=ancestor::div[2]')
+		const paddingBottom = await barContainer.evaluate(el => getComputedStyle(el).paddingBottom)
+		expect(paddingBottom).not.toBe('0px')
+	})
+})


### PR DESCRIPTION
Closes #11

- Added `MobileCtaBar` fixed at bottom on mobile (`md:hidden`)
  - Tailwind-only; high-contrast colors; visible focus rings
  - Targets ≥ 44px height
  - Safe-area padding: `pb-[max(env(safe-area-inset-bottom),12px)]`
  - “Call” uses `href="tel:+447123456789"`
  - “Get Quote” scrolls to `#contact` and focuses `#name`
- Mounted globally in `web/app/layout.tsx`; added `export const viewport = { viewportFit: 'cover' }`
- e2e: `web/tests/e2e/mobile-cta-bar.spec.ts`
  - Renders on mobile; tel href; scroll + focus; ≥44px targets; focus rings; safe-area padding
  - Smoke suite remains green
- Dependency bump
  - `next` → 15.5.2 and `eslint-config-next` → 15.5.2 (addresses GHSA-4342-x723-ch2f; no middleware in app)

How to test
- Narrow viewport or iPhone/Android devices
- Verify bar stays visible with keyboard open/closed
- Confirm focus ring visibility and contrast
- Click “Get Quote” → scrolls to contact and focuses first field

No new deps; ESLint/TS config unchanged.