### PR TITLE
feat: tabs nav — [Services][Work][Reviews][More]

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -14,6 +14,9 @@
   --gold: var(--accent);
   --dark-navy: var(--bg-900);
   --light-navy: #1a1f2e;
+  /* dynamic heights for fixed mobile UI */
+  --cta-height: 0px;
+  --tabs-height: 0px;
 }
 
 body {
@@ -21,6 +24,13 @@ body {
   background-image: linear-gradient(180deg, var(--bg-900), var(--bg-950));
   color: #f0f0f0;
   overflow-x: hidden;
+}
+
+/* Ensure content is not obscured by fixed bottom bars on small screens */
+@media (max-width: 767px) {
+  main {
+    padding-bottom: calc(var(--cta-height) + var(--tabs-height) + 12px);
+  }
 }
 
 /* Glassmorphism Card Effect */

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -4,6 +4,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { ScrollProgress } from "../components/ScrollProgress";
 import StickyContactBar from "../components/StickyContactBar";
 import MobileCtaBar from "../components/MobileCtaBar";
+import MobileTabsNav from "../components/MobileTabsNav";
 import "./globals.css";
 
 const inter = Inter({ subsets: ['latin'] })
@@ -35,6 +36,7 @@ export default function RootLayout({
         <ScrollProgress />
         {children}
         <StickyContactBar />
+        <MobileTabsNav />
         <MobileCtaBar />
         <Analytics />
       </body>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -36,8 +36,10 @@ export default function RootLayout({
         <ScrollProgress />
         {children}
         <StickyContactBar />
-        <MobileTabsNav />
+        {/* Primary actions nav first in DOM for focus order */}
         <MobileCtaBar />
+        {/* Secondary tabs nav after CTA in DOM */}
+        <MobileTabsNav />
         <Analytics />
       </body>
     </html>

--- a/web/components/MobileCtaBar.tsx
+++ b/web/components/MobileCtaBar.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import Link from "next/link";
 import { CONTACT_INFO } from "@/config/contact";
 
 export default function MobileCtaBar() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
   const handleGetQuote = useCallback((e: React.MouseEvent<HTMLAnchorElement>) => {
     // Respect modifier/middle clicks and let browser handle them
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button === 1) return;
@@ -32,9 +34,30 @@ export default function MobileCtaBar() {
     // Otherwise allow navigation to the route (keep href="#contact" on same page; consider "/#contact" if needed)
   }, []);
 
+  // Expose CTA height to CSS var so other UI can offset
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      const h = el.offsetHeight || 0;
+      document.documentElement.style.setProperty("--cta-height", `${h}px`);
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    window.addEventListener("orientationchange", update);
+    window.addEventListener("load", update);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("orientationchange", update);
+      window.removeEventListener("load", update);
+    };
+  }, []);
+
   return (
     <div
       className="md:hidden fixed bottom-0 inset-x-0 z-50 bg-slate-900/95 backdrop-blur border-t border-slate-700/60"
+      ref={containerRef}
     >
       <div
         className="px-4 pt-2 pb-2 pb-[max(env(safe-area-inset-bottom),12px)]"

--- a/web/components/MobileTabsNav.tsx
+++ b/web/components/MobileTabsNav.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { Hammer, Briefcase, Star, MoreHorizontal } from "lucide-react";
+
+type TabItem = {
+  href: string;
+  label: string;
+  icon: React.ComponentType<{ size?: number; className?: string }>;
+  id: string; // section id without '#'
+};
+
+const TABS: readonly TabItem[] = [
+  { href: "#services", label: "Services", icon: Hammer, id: "services" },
+  { href: "#portfolio", label: "Work", icon: Briefcase, id: "portfolio" },
+  { href: "#testimonials", label: "Reviews", icon: Star, id: "testimonials" },
+  // Map "More" to About section for now
+  { href: "#about", label: "More", icon: MoreHorizontal, id: "about" },
+] as const;
+
+export default function MobileTabsNav() {
+  const [activeId, setActiveId] = useState<string>(TABS[0].id);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  // Observe section visibility to set active tab
+  useEffect(() => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+
+    const sections = TABS.map(t => document.getElementById(t.id)).filter(Boolean) as HTMLElement[];
+    if (sections.length === 0) return;
+
+    const io = new IntersectionObserver(
+      entries => {
+        // choose the section with greatest intersection ratio in viewport bottom area
+        let topCandidate: { id: string; ratio: number; top: number } | null = null;
+        for (const e of entries) {
+          if (!e.isIntersecting) continue;
+          const rect = e.target.getBoundingClientRect();
+          const ratio = e.intersectionRatio + Math.max(0, 1 - Math.abs(rect.top) / window.innerHeight);
+          const id = (e.target as HTMLElement).id;
+          if (!topCandidate || ratio > topCandidate.ratio) {
+            topCandidate = { id, ratio, top: rect.top };
+          }
+        }
+        if (topCandidate) setActiveId(topCandidate.id);
+      },
+      { rootMargin: "0px 0px -50% 0px", threshold: [0, 0.25, 0.5, 0.75, 1] }
+    );
+    sections.forEach(s => io.observe(s));
+    observerRef.current = io;
+    return () => io.disconnect();
+  }, []);
+
+  // Expose height to CSS var for layout padding calculations
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => {
+      const h = el.offsetHeight;
+      document.documentElement.style.setProperty("--tabs-height", `${h}px`);
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    window.addEventListener("orientationchange", update);
+    window.addEventListener("load", update);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("orientationchange", update);
+      window.removeEventListener("load", update);
+    };
+  }, []);
+
+  const items = useMemo(() => TABS, []);
+
+  return (
+    <nav
+      aria-label="Site navigation"
+      className="md:hidden fixed inset-x-0 z-[55] bg-slate-900/95 backdrop-blur border-t border-slate-700/60"
+      style={{ bottom: "var(--cta-height)" }}
+      ref={containerRef}
+    >
+      <ul className="flex items-stretch justify-around px-2 pt-1 pb-1 pb-[max(env(safe-area-inset-bottom),8px)]">
+        {items.map(item => {
+          const Icon = item.icon;
+          const isActive = activeId === item.id;
+          return (
+            <li key={item.id} className="flex-1">
+              <Link
+                href={item.href}
+                aria-current={isActive ? "page" : undefined}
+                className={`flex flex-col items-center justify-center gap-1 h-12 min-h-[44px] rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
+                  isActive ? "text-amber-400" : "text-gray-300 hover:text-white"
+                }`}
+              >
+                <Icon size={18} aria-hidden="true" />
+                <span className="text-[11px] leading-none">{item.label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+


### PR DESCRIPTION
Implements a secondary, compact tabs navigation under the mobile CTA bar.

- Icons + labels; touch targets ≥44px
- Primary actions (CTA) precede Tabs in focus order
- Active tab via IntersectionObserver; sets aria-current="page"
- Content bottom padding uses CSS vars for CTA + Tabs heights so nothing is obscured

Closes #12.