### PR TITLE
Migrate to ESLint CLI and add Playwright linting

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -9,8 +9,25 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
+const playwrightOverrides = compat
+  .extends("plugin:playwright/recommended")
+  .map((conf) => ({
+    ...conf,
+    files: ["tests/e2e/**", "web/tests/e2e/**"],
+  }));
+
 const eslintConfig = [
+  {
+    ignores: [
+      "node_modules/**",
+      ".next/**",
+      "out/**",
+      "build/**",
+      "next-env.d.ts",
+    ],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...playwrightOverrides,
 ];
 
 export default eslintConfig;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,8 +29,12 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "^15.5.2",
+        "eslint-plugin-playwright": "^2.2.2",
         "tailwindcss": "^4",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=18.18.0 <19 || >=20.9.0 <21 || >=22"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4281,6 +4285,38 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-playwright": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.2.2.tgz",
+      "integrity": "sha512-j0jKpndIPOXRRP9uMkwb9l/nSmModOU3452nrFdgFJoEv/435J1onk8+aITzjDW8DfypxgmVaDMdmVIa6F7I0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^13.23.0"
+      },
+      "engines": {
+        "node": ">=16.6.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.40.0"
+      }
+    },
+    "node_modules/eslint-plugin-playwright/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -8084,6 +8120,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typed-array-buffer": {

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "playwright:install": "playwright install --with-deps",
     "email": "email dev --dir emails --port 3001",
     "start:test": "next build && next start -p 3000",
@@ -40,6 +41,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "^15.5.2",
+    "eslint-plugin-playwright": "^2.2.2",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/web/tests/e2e/testimonials.spec.ts
+++ b/web/tests/e2e/testimonials.spec.ts
@@ -26,7 +26,7 @@ test.describe('Testimonials', () => {
     // Verify autoplay is paused for at least 5s after manual interaction
     await page.waitForTimeout(5500)
     const stillSame = await quote.textContent()
-    expect(stillSame).toBe(afterClick)
+    await expect(quote).toHaveText(afterClick || '')
 
     // Keyboard navigation (ArrowRight) should move to next testimonial
     await section.focus()


### PR DESCRIPTION
This PR migrates the project from `next lint` to the ESLint CLI and adds Playwright linting for E2E tests.

Changes:
- Ran `npx @next/codemod@canary next-lint-to-eslint-cli .`
- Updated `web/package.json` scripts:
  - `lint`: `eslint .`
  - `lint:fix`: `eslint . --fix`
- Installed `eslint-plugin-playwright`
- Enabled `plugin:playwright/recommended` for `web/tests/e2e/**` in `eslint.config.mjs`
- Fixed one Playwright lint error in `testimonials.spec.ts`

Notes:
- Remaining warnings are mostly about `waitForTimeout` and unused types; they can be addressed in follow-ups.

Closes #33