### PR TITLE
Replace deprecated Playwright accessibility snapshot with Axe checks

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "split-type": "^0.3.4"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.2",
         "@eslint/eslintrc": "^3",
         "@playwright/test": "^1.54.2",
         "@tailwindcss/postcss": "^4",
@@ -62,6 +63,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+      "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "split-type": "^0.3.4"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
     "@eslint/eslintrc": "^3",
     "@playwright/test": "^1.54.2",
     "@tailwindcss/postcss": "^4",

--- a/web/tests/e2e/testimonials.spec.ts
+++ b/web/tests/e2e/testimonials.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { AxeBuilder } from '@axe-core/playwright'
 
 test.describe('Testimonials', () => {
   test('renders and supports navigation and autoplay pause', async ({ page }) => {
@@ -46,9 +47,9 @@ test.describe('Testimonials', () => {
     // Accessible label should match rounded rating and max handling
     const aria = await stars.getAttribute('aria-label')
     expect(aria).toMatch(/Rated \d+ out of 5/)
-    // Optional: a11y snapshot for coverage
-    const ax = await page.accessibility.snapshot({ root: (await section.elementHandle())! })
-    expect(ax).toBeTruthy()
+    // A11y: Axe scan scoped to testimonials section
+    const results = await new AxeBuilder({ page }).include('#testimonials').analyze()
+    expect(results.violations).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
This PR replaces deprecated `page.accessibility.snapshot` usage with Axe-based accessibility checks.

- Added `@axe-core/playwright` as a dev dependency in `web`
- Updated `web/tests/e2e/testimonials.spec.ts` to use `AxeBuilder` scoped to `#testimonials`
- Searched for any other `page.accessibility.*` usages; none found

Testing:
- Lint passes: `npm run lint`
- Smoke tests to be run: `npm run test:e2e:smoke`

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end accessibility checks for the Testimonials section using automated a11y analysis and assertions to ensure zero violations.
  * Replaced a basic accessibility snapshot with a stricter, results-based validation to catch real issues.

* **Chores**
  * Added a development dependency to support automated accessibility testing in the web app’s test suite.
  * No impact on runtime behavior or public API; changes are limited to development and testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->