### PR TITLE
feat(web): smart scroll behavior for header + mobile CTA shadow

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -63,6 +63,7 @@ body {
 
 /* Sticky Nav Styling */
 .sticky-nav {
+    will-change: transform;
     transition: transform 0.4s ease-in-out, background 0.3s ease-in-out, border-color 0.3s ease-in-out;
 }
 
@@ -76,6 +77,7 @@ body {
 /* Hide header when scrolling down */
 .sticky-nav--hidden {
   transform: translateY(-100%);
+  pointer-events: none;
 }
 
 /* Bottom CTA shadow on scroll */
@@ -87,6 +89,9 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .sticky-nav {
     transition: none !important;
+  }
+  html, :root {
+    scroll-behavior: auto !important;
   }
 }
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -63,7 +63,7 @@ body {
 
 /* Sticky Nav Styling */
 .sticky-nav {
-    transition: all 0.4s ease-in-out;
+    transition: transform 0.4s ease-in-out, background 0.3s ease-in-out, border-color 0.3s ease-in-out;
 }
 
 .sticky-nav.scrolled {
@@ -71,6 +71,23 @@ body {
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border-bottom: 1px solid color-mix(in oklab, var(--accent) 30%, transparent);
+}
+
+/* Hide header when scrolling down */
+.sticky-nav--hidden {
+  transform: translateY(-100%);
+}
+
+/* Bottom CTA shadow on scroll */
+.bottom-cta--shadow {
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Respect reduced motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .sticky-nav {
+    transition: none !important;
+  }
 }
 
 /* Parallax Effect */

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -1,9 +1,53 @@
 "use client";
 import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
 
 export default function Header() {
+  const [isHidden, setIsHidden] = useState(false);
+  const [isScrolled, setIsScrolled] = useState(false);
+  const lastScrollYRef = useRef(0);
+  const showTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const y = window.scrollY || 0;
+      setIsScrolled(y > 0);
+
+      const last = lastScrollYRef.current;
+      lastScrollYRef.current = y;
+
+      const isScrollingDown = y > last;
+
+      if (isScrollingDown) {
+        if (showTimeoutRef.current) {
+          window.clearTimeout(showTimeoutRef.current);
+          showTimeoutRef.current = null;
+        }
+        setIsHidden(true);
+      } else {
+        if (showTimeoutRef.current) {
+          window.clearTimeout(showTimeoutRef.current);
+        }
+        showTimeoutRef.current = window.setTimeout(() => {
+          setIsHidden(false);
+        }, 100);
+      }
+    };
+
+    // Initialize state on mount
+    lastScrollYRef.current = window.scrollY || 0;
+    setIsScrolled(lastScrollYRef.current > 0);
+    setIsHidden(false);
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll as EventListener);
+      if (showTimeoutRef.current) window.clearTimeout(showTimeoutRef.current);
+    };
+  }, []);
+
   return (
-    <header id="navbar" className="sticky-nav fixed top-0 left-0 right-0 z-50">
+    <header id="navbar" className={`sticky-nav fixed top-0 left-0 right-0 z-50 ${isScrolled ? "scrolled" : ""} ${isHidden ? "sticky-nav--hidden" : ""}`}>
       <div className="container mx-auto px-6 py-3">
         <div className="flex justify-between items-center">
           <div className="text-2xl font-bold text-white">

--- a/web/components/MobileCtaBar.tsx
+++ b/web/components/MobileCtaBar.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { CONTACT_INFO } from "@/config/contact";
 
 export default function MobileCtaBar() {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const [scrolled, setScrolled] = useState(false);
 
   const handleGetQuote = useCallback((e: React.MouseEvent<HTMLAnchorElement>) => {
     // Respect modifier/middle clicks and let browser handle them
@@ -57,10 +58,20 @@ export default function MobileCtaBar() {
     };
   }, []);
 
+  // Add subtle shadow when the page is scrolled
+  useEffect(() => {
+    const onScroll = () => {
+      setScrolled((window.scrollY || 0) > 0);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll as EventListener);
+  }, []);
+
   return (
     <nav
       aria-label="Primary actions"
-      className="md:hidden fixed bottom-0 inset-x-0 z-50 bg-slate-900/95 backdrop-blur border-t border-slate-700/60"
+      className={`md:hidden fixed bottom-0 inset-x-0 z-50 bg-slate-900/95 backdrop-blur border-t border-slate-700/60 ${scrolled ? "bottom-cta--shadow" : ""}`}
       ref={containerRef}
     >
       <div

--- a/web/components/MobileCtaBar.tsx
+++ b/web/components/MobileCtaBar.tsx
@@ -62,11 +62,15 @@ export default function MobileCtaBar() {
   // Add subtle shadow when the page is scrolled
   useEffect(() => {
     const onScroll = () => {
-      setScrolled((window.scrollY || 0) > 0);
+      const y = Math.max(0, window.scrollY || 0);
+      setScrolled((prev) => {
+        const next = y > 0;
+        return prev === next ? prev : next;
+      });
     };
     onScroll();
     window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll as EventListener);
+    return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
   return (

--- a/web/tests/e2e/smoke/menu-contact-links.smoke.spec.ts
+++ b/web/tests/e2e/smoke/menu-contact-links.smoke.spec.ts
@@ -31,11 +31,8 @@ test.describe('Smoke @smoke - Contact links in menu drawer', () => {
     // Also assert accessible name via aria-label for stability
     await expect(whatsappHref).toHaveAttribute('aria-label', /whatsapp/i)
     await expect(whatsappHref).toHaveAttribute('target', '_blank')
-    const relValue = await whatsappHref.getAttribute('rel')
-    expect(relValue).toBeTruthy()
-    const relParts = (relValue ?? '').trim().split(/\s+/)
-    expect(relParts).toContain('noopener')
-    expect(relParts).toContain('noreferrer')
+    await expect(whatsappHref).toHaveAttribute('rel', /(^|\s)noopener(\s|$)/)
+    await expect(whatsappHref).toHaveAttribute('rel', /(^|\s)noreferrer(\s|$)/)
 
     const email = dialog.getByRole('link', { name: 'Email' })
     await expect(email).toBeVisible()

--- a/web/tests/e2e/smoke/smart-scroll.spec.ts
+++ b/web/tests/e2e/smoke/smart-scroll.spec.ts
@@ -11,22 +11,20 @@ test.describe('Smart Scroll Behavior @smoke', () => {
     await expect(header).not.toHaveClass(/sticky-nav--hidden/)
 
     // Scroll down to trigger hide
-    await page.evaluate(() => window.scrollTo({ top: 800, behavior: 'instant' as any }))
-    await page.waitForTimeout(150)
+    await page.evaluate(() => window.scrollTo({ top: 800, behavior: 'auto' }))
     await expect(header).toHaveClass(/sticky-nav--hidden/)
 
     // Scroll up to trigger show (with 100ms debounce)
-    await page.evaluate(() => window.scrollTo({ top: 100, behavior: 'instant' as any }))
-    await page.waitForTimeout(200)
+    await page.evaluate(() => window.scrollTo({ top: 100, behavior: 'auto' }))
     await expect(header).not.toHaveClass(/sticky-nav--hidden/)
 
     // Bottom CTA bar shadow when scrolled
     const cta = page.locator('nav[aria-label="Primary actions"]')
-    await expect(cta).toBeVisible()
+    await cta.waitFor({ state: 'visible', timeout: 5000 })
     await expect(cta).toHaveClass(/bottom-cta--shadow/)
     // Scroll to top, shadow can disappear
-    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' as any }))
-    await page.waitForTimeout(100)
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'auto' }))
+    await page.waitForTimeout(250)
     await expect(cta).not.toHaveClass(/bottom-cta--shadow/)
 
     // Basic a11y snapshot capture to ensure no crash
@@ -34,5 +32,5 @@ test.describe('Smart Scroll Behavior @smoke', () => {
     expect(ax).toBeTruthy()
   })
 })
-
+ 
 

--- a/web/tests/e2e/smoke/smart-scroll.spec.ts
+++ b/web/tests/e2e/smoke/smart-scroll.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Smart Scroll Behavior @smoke', () => {
+  test('header hides on scroll down, shows on scroll up; bottom CTA shadow toggles', async ({ page }) => {
+    await page.goto('/')
+
+    const header = page.locator('#navbar')
+    await expect(header).toBeVisible()
+
+    // Ensure initial state not hidden
+    await expect(header).not.toHaveClass(/sticky-nav--hidden/)
+
+    // Scroll down to trigger hide
+    await page.evaluate(() => window.scrollTo({ top: 800, behavior: 'instant' as any }))
+    await page.waitForTimeout(150)
+    await expect(header).toHaveClass(/sticky-nav--hidden/)
+
+    // Scroll up to trigger show (with 100ms debounce)
+    await page.evaluate(() => window.scrollTo({ top: 100, behavior: 'instant' as any }))
+    await page.waitForTimeout(200)
+    await expect(header).not.toHaveClass(/sticky-nav--hidden/)
+
+    // Bottom CTA bar shadow when scrolled
+    const cta = page.locator('nav[aria-label="Primary actions"]')
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveClass(/bottom-cta--shadow/)
+    // Scroll to top, shadow can disappear
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'instant' as any }))
+    await page.waitForTimeout(100)
+    await expect(cta).not.toHaveClass(/bottom-cta--shadow/)
+
+    // Basic a11y snapshot capture to ensure no crash
+    const ax = await page.accessibility.snapshot()
+    expect(ax).toBeTruthy()
+  })
+})
+
+

--- a/web/tests/e2e/smoke/smart-scroll.spec.ts
+++ b/web/tests/e2e/smoke/smart-scroll.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from '@playwright/test'
 
 test.describe('Smart Scroll Behavior @smoke', () => {
+  // Ensure mobile layout so MobileCtaBar is visible (md:hidden on desktop)
+  test.use({ viewport: { width: 390, height: 844 } })
   test('header hides on scroll down, shows on scroll up; bottom CTA shadow toggles', async ({ page }) => {
     await page.goto('/')
 
@@ -12,20 +14,20 @@ test.describe('Smart Scroll Behavior @smoke', () => {
 
     // Scroll down to trigger hide
     await page.evaluate(() => window.scrollTo({ top: 800, behavior: 'auto' }))
-    await expect(header).toHaveClass(/sticky-nav--hidden/)
+    await expect(header).toHaveClass(/sticky-nav--hidden/, { timeout: 15000 })
 
     // Scroll up to trigger show (with 100ms debounce)
     await page.evaluate(() => window.scrollTo({ top: 100, behavior: 'auto' }))
-    await expect(header).not.toHaveClass(/sticky-nav--hidden/)
+    await expect(header).not.toHaveClass(/sticky-nav--hidden/, { timeout: 15000 })
 
     // Bottom CTA bar shadow when scrolled
     const cta = page.locator('nav[aria-label="Primary actions"]')
     await cta.waitFor({ state: 'visible', timeout: 5000 })
-    await expect(cta).toHaveClass(/bottom-cta--shadow/)
+    await expect(cta).toHaveClass(/bottom-cta--shadow/, { timeout: 15000 })
     // Scroll to top, shadow can disappear
     await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'auto' }))
-    await page.waitForTimeout(250)
-    await expect(cta).not.toHaveClass(/bottom-cta--shadow/)
+    await page.waitForTimeout(500)
+    await expect(cta).not.toHaveClass(/bottom-cta--shadow/, { timeout: 15000 })
 
     // Basic a11y snapshot capture to ensure no crash
     const ax = await page.accessibility.snapshot()

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/web/types/axe-core-playwright.d.ts
+++ b/web/types/axe-core-playwright.d.ts
@@ -1,0 +1,3 @@
+declare module '@axe-core/playwright';
+
+


### PR DESCRIPTION
Implements ticket #27 - Smart Scroll Behavior.

Changes:
- Header hides on scroll down, shows on scroll up (100ms debounce)
- Sticky header gets translucent background + border when scrolled
- Bottom CTA bar remains sticky and gains shadow on scroll
- Respects prefers-reduced-motion: disables transitions
- Added Playwright smoke test under `web/tests/e2e/smoke/smart-scroll.spec.ts`

Testing:
- `npm ci` in `web/` then `npm run test:e2e:smoke`

Definition of Done:
- Branch matches naming convention
- Conventional commit used
- Smoke test present
- Linked to issue #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Header auto-hides on scroll down and reappears on scroll up.
  - Mobile CTA bar gains a subtle shadow when the page is scrolled.

- Improvements
  - More granular, smoother header transitions and reduced-motion support.
  - Mobile menu trigger keeps aria-expanded synced.

- Tests
  - New E2E test for header smart-scroll, CTA shadow, and accessibility snapshot.
  - Updated contact-link test to assert rel tokens via regex.

- Chores
  - Type declarations and TypeScript include updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->