### PR TITLE
feat(cta): optimize bottom CTAs, add smoke tests

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -10,6 +10,10 @@
   --bg-900: #0f172a; /* Dark navy */
   --surface: rgba(255, 255, 255, 0.06);
 
+  /* Layering */
+  --z-modal-overlay: 200;
+  --z-modal-content: 210;
+
   /* Deprecated (kept for compatibility with existing class names) */
   --gold: var(--accent);
   --dark-navy: var(--bg-900);

--- a/web/components/EnhancedHero.tsx
+++ b/web/components/EnhancedHero.tsx
@@ -35,7 +35,7 @@ export function EnhancedHero({ children }: EnhancedHeroProps) {
   return (
     <section ref={heroRef} className="relative min-h-screen supports-[height:100dvh]:min-h-[100dvh] overflow-hidden">
       {/* Background with parallax */}
-      <motion.div style={{ y: backgroundY }} className="absolute inset-0 z-0">
+      <motion.div style={{ y: backgroundY }} className="absolute inset-0 z-0 pointer-events-none">
         {/* Single responsive image with sizes; lets the browser pick the right src from Next.js-generated srcset */}
         <div className="absolute inset-0">
           <Image

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -85,7 +85,7 @@ export default function Header() {
   return (
     <header
       id="navbar"
-      className={`sticky-nav fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur border-b border-slate-200/60 ${isHidden ? "sticky-nav--hidden" : ""}`}
+      className={`sticky-nav fixed top-0 left-0 right-0 z-[120] bg-white/80 backdrop-blur border-b border-slate-200/60 ${isHidden ? "sticky-nav--hidden" : ""}`}
     >
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-14">
@@ -125,5 +125,4 @@ export default function Header() {
     </header>
   );
 }
-
 

--- a/web/components/Hero.tsx
+++ b/web/components/Hero.tsx
@@ -19,13 +19,7 @@ export default function Hero() {
         </p>
 
         {/* CTAs with mobile-first sizing */}
-        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
-          <Link
-            href="/contact"
-            className="cta-btn text-slate-900 font-bold py-3 sm:py-4 px-6 sm:px-8 rounded-lg"
-          >
-            Get a Quote
-          </Link>
+        <div className="flex justify-center">
           <Link
             href="#portfolio"
             className="border-2 border-amber-500 text-amber-500 hover:bg-amber-500 hover:text-slate-900 font-bold py-3 sm:py-4 px-6 sm:px-8 rounded-lg transition-colors"
@@ -37,4 +31,3 @@ export default function Hero() {
     </EnhancedHero>
   )
 }
-

--- a/web/components/MobileCtaBar.tsx
+++ b/web/components/MobileCtaBar.tsx
@@ -79,6 +79,7 @@ export default function MobileCtaBar() {
     <nav
       aria-label="Primary actions"
       className={`md:hidden fixed bottom-0 inset-x-0 z-50 backdrop-blur-xl bg-white/70 border-t border-white/60 shadow-lg ${scrolled ? "bottom-cta--shadow" : ""}`}
+      data-shadowed={scrolled ? "true" : "false"}
       ref={containerRef}
     >
       <div
@@ -90,6 +91,8 @@ export default function MobileCtaBar() {
             href={`tel:${CONTACT_INFO.phoneE164}`}
             aria-label={`Call ${CONTACT_INFO.phoneE164}`}
             className="group inline-flex h-12 min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-slate-200/70 bg-white/5 px-3 text-sm font-semibold text-slate-900 transition-colors hover:bg-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900/20 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            data-testid="mobile-cta-link"
+            data-action="call"
           >
             <Phone size={18} aria-hidden="true" className="text-slate-800 transition-transform group-hover:-translate-y-0.5" />
             <span>Call</span>
@@ -100,6 +103,8 @@ export default function MobileCtaBar() {
             target="_blank"
             aria-label="WhatsApp chat with Pat"
             className="group inline-flex h-12 min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-emerald-300/80 bg-transparent px-3 text-sm font-semibold text-emerald-900 transition-colors hover:bg-emerald-50/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            data-testid="mobile-cta-link"
+            data-action="whatsapp"
           >
             <MessageCircle size={18} aria-hidden="true" className="transition-transform group-hover:-translate-y-0.5" />
             <span>WhatsApp</span>
@@ -108,6 +113,8 @@ export default function MobileCtaBar() {
             href="/#contact"
             onClick={handleGetQuote}
             className="group inline-flex h-12 min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-amber-300/80 bg-transparent px-3 text-sm font-semibold text-amber-900 transition-colors hover:bg-amber-50/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+            data-testid="mobile-cta-link"
+            data-action="get-quote"
           >
             <ClipboardList size={18} aria-hidden="true" className="transition-transform group-hover:-translate-y-0.5" />
             <span>Get Quote</span>

--- a/web/components/MobileCtaBar.tsx
+++ b/web/components/MobileCtaBar.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ClipboardList, MessageCircle, Phone } from "lucide-react";
-import { CONTACT_INFO } from "@/config/contact";
+import { CONTACT_INFO, WHATSAPP_PRESET } from "@/config/contact";
 
 export default function MobileCtaBar() {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -94,7 +94,7 @@ export default function MobileCtaBar() {
             <span>Call</span>
           </a>
           <a
-            href={`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent("Hi Pat, ")}`}
+            href={`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent(WHATSAPP_PRESET)}`}
             rel="noopener noreferrer"
             target="_blank"
             aria-label="WhatsApp chat with Pat"

--- a/web/components/MobileCtaBar.tsx
+++ b/web/components/MobileCtaBar.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import { ClipboardList, MessageCircle, Phone } from "lucide-react";
 import { CONTACT_INFO } from "@/config/contact";
 
 export default function MobileCtaBar() {
@@ -76,41 +77,42 @@ export default function MobileCtaBar() {
   return (
     <nav
       aria-label="Primary actions"
-      className={`md:hidden fixed bottom-0 inset-x-0 z-50 bg-slate-900/95 backdrop-blur border-t border-slate-700/60 ${scrolled ? "bottom-cta--shadow" : ""}`}
+      className={`md:hidden fixed bottom-0 inset-x-0 z-50 backdrop-blur-xl bg-white/70 border-t border-white/60 shadow-lg ${scrolled ? "bottom-cta--shadow" : ""}`}
       ref={containerRef}
     >
       <div
-        className="px-4 pt-2 pb-[max(env(safe-area-inset-bottom),12px)]"
+        className="px-4 pt-3 pb-[max(env(safe-area-inset-bottom),12px)]"
         data-testid="mobile-cta-padding"
       >
-        <div className="max-w-screen-md mx-auto grid grid-cols-3 gap-3">
+        <div className="max-w-screen-md mx-auto grid grid-cols-3 gap-2">
           <a
             href={`tel:${CONTACT_INFO.phoneE164}`}
             aria-label={`Call ${CONTACT_INFO.phoneE164}`}
-            className="inline-flex items-center justify-center h-12 min-h-[44px] rounded-lg bg-blue-700 text-white font-semibold shadow-sm hover:bg-blue-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 transition-colors"
+            className="group inline-flex h-12 min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-slate-200/70 bg-white/5 px-3 text-sm font-semibold text-slate-900 transition-colors hover:bg-white/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900/20 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           >
-            Call
+            <Phone size={18} aria-hidden="true" className="text-slate-800 transition-transform group-hover:-translate-y-0.5" />
+            <span>Call</span>
           </a>
           <a
-            href={`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent("Hi Pat,")}`}
+            href={`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent("Hi Pat, ")}`}
             rel="noopener noreferrer"
             target="_blank"
             aria-label="WhatsApp chat with Pat"
-            className="inline-flex items-center justify-center h-12 min-h-[44px] rounded-lg bg-green-600 text-white font-semibold shadow-sm hover:bg-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 transition-colors"
+            className="group inline-flex h-12 min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-emerald-300/80 bg-transparent px-3 text-sm font-semibold text-emerald-900 transition-colors hover:bg-emerald-50/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           >
-            WhatsApp
+            <MessageCircle size={18} aria-hidden="true" className="transition-transform group-hover:-translate-y-0.5" />
+            <span>WhatsApp</span>
           </a>
           <Link
             href="/#contact"
             onClick={handleGetQuote}
-            className="inline-flex items-center justify-center h-12 min-h-[44px] rounded-lg bg-amber-500 text-slate-900 font-semibold shadow-sm hover:bg-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 transition-colors"
+            className="group inline-flex h-12 min-h-[44px] items-center justify-center gap-2 rounded-2xl border border-amber-300/80 bg-transparent px-3 text-sm font-semibold text-amber-900 transition-colors hover:bg-amber-50/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
           >
-            Get Quote
+            <ClipboardList size={18} aria-hidden="true" className="transition-transform group-hover:-translate-y-0.5" />
+            <span>Get Quote</span>
           </Link>
         </div>
       </div>
     </nav>
   );
 }
-
-

--- a/web/components/MobileCtaBar.tsx
+++ b/web/components/MobileCtaBar.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ClipboardList, MessageCircle, Phone } from "lucide-react";
-import { CONTACT_INFO, WHATSAPP_PRESET } from "@/config/contact";
+import { CONTACT_INFO, whatsappHref } from "@/config/contact";
 
 export default function MobileCtaBar() {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -46,13 +46,14 @@ export default function MobileCtaBar() {
       document.documentElement.style.setProperty("--cta-height", `${h}px`);
     };
     update();
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
+    const ResizeObserverCtor = typeof window !== "undefined" ? (window as typeof window & { ResizeObserver?: typeof ResizeObserver }).ResizeObserver : undefined;
+    const ro = typeof ResizeObserverCtor === "function" ? new ResizeObserverCtor(update) : null;
+    ro?.observe?.(el);
     window.addEventListener("orientationchange", update);
     window.addEventListener("resize", update);
     window.addEventListener("load", update);
     return () => {
-      ro.disconnect();
+      ro?.disconnect?.();
       window.removeEventListener("orientationchange", update);
       window.removeEventListener("resize", update);
       window.removeEventListener("load", update);
@@ -94,7 +95,7 @@ export default function MobileCtaBar() {
             <span>Call</span>
           </a>
           <a
-            href={`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent(WHATSAPP_PRESET)}`}
+            href={whatsappHref()}
             rel="noopener noreferrer"
             target="_blank"
             aria-label="WhatsApp chat with Pat"

--- a/web/components/MobileTabsNav.tsx
+++ b/web/components/MobileTabsNav.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { Drawer } from "vaul";
 import { Mail as MailIcon, MessageCircle as WhatsAppIcon, X as XIcon } from "lucide-react";
 import { track } from "@vercel/analytics";
-import { CONTACT_INFO, WHATSAPP_PRESET } from "@/config/contact";
+import { CONTACT_INFO, whatsappHref } from "@/config/contact";
 import { OPEN_MOBILE_MENU, MOBILE_MENU_STATE } from "@/lib/mobileMenuEvents";
 import type { OpenMobileMenuDetail } from "@/lib/mobileMenuEvents";
 
@@ -210,7 +210,7 @@ export default function MobileTabsNav() {
               <h4 className="sr-only">Contact</h4>
               <div className="grid grid-cols-1 gap-2">
                 <a
-                  href={`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent(WHATSAPP_PRESET)}`}
+                  href={whatsappHref()}
                   rel="noopener noreferrer"
                   target="_blank"
                   className="py-3 min-h-[44px] inline-flex items-center gap-2 text-gray-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 rounded"

--- a/web/components/MobileTabsNav.tsx
+++ b/web/components/MobileTabsNav.tsx
@@ -39,13 +39,13 @@ export default function MobileTabsNav() {
       (openerRef.current ??
         (document.querySelector('[data-menu-trigger="mobile-menu"]') as HTMLElement | null))?.focus({ preventScroll: true });
     };
-    if (typeof queueMicrotask === "function") {
-      queueMicrotask(() => {
-        focusOpener();
-        window.setTimeout(focusOpener, 0);
-      });
-    } else {
+    const schedule = () => {
       window.setTimeout(focusOpener, 0);
+    };
+    if (typeof queueMicrotask === "function") {
+      queueMicrotask(schedule);
+    } else {
+      schedule();
     }
   }, []);
 

--- a/web/components/MobileTabsNav.tsx
+++ b/web/components/MobileTabsNav.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { Drawer } from "vaul";
 import { Mail as MailIcon, MessageCircle as WhatsAppIcon, X as XIcon } from "lucide-react";
 import { track } from "@vercel/analytics";
-import { CONTACT_INFO } from "@/config/contact";
+import { CONTACT_INFO, WHATSAPP_PRESET } from "@/config/contact";
 import { OPEN_MOBILE_MENU, MOBILE_MENU_STATE } from "@/lib/mobileMenuEvents";
 import type { OpenMobileMenuDetail } from "@/lib/mobileMenuEvents";
 
@@ -159,7 +159,7 @@ export default function MobileTabsNav() {
         modal
       >
         <Drawer.Overlay
-          className="fixed inset-0 bg-black/50 z-[70] md:hidden"
+          className="fixed inset-0 bg-black/50 z-[200] md:hidden"
           data-testid="menu-overlay"
           onClick={() => closeMenu("backdrop")}
         />
@@ -168,7 +168,7 @@ export default function MobileTabsNav() {
           role="dialog"
           aria-modal="true"
           aria-labelledby="mobile-menu-title"
-          className="fixed inset-x-0 bottom-0 z-[80] md:hidden bg-slate-900 border-t border-slate-700/60 rounded-t-2xl shadow-2xl"
+          className="fixed inset-x-0 bottom-0 z-[210] md:hidden bg-slate-900 border-t border-slate-700/60 rounded-t-2xl shadow-2xl"
           style={{ paddingBottom: "max(env(safe-area-inset-bottom), 12px)" }}
         >
           <div className="max-w-screen-md mx-auto px-4 pt-2 pb-2">
@@ -210,7 +210,7 @@ export default function MobileTabsNav() {
               <h4 className="sr-only">Contact</h4>
               <div className="grid grid-cols-1 gap-2">
                 <a
-                  href={`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent("Hi Pat,")}`}
+                  href={`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent(WHATSAPP_PRESET)}`}
                   rel="noopener noreferrer"
                   target="_blank"
                   className="py-3 min-h-[44px] inline-flex items-center gap-2 text-gray-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 rounded"

--- a/web/components/WhatsAppWidget.tsx
+++ b/web/components/WhatsAppWidget.tsx
@@ -1,11 +1,12 @@
-import { CONTACT_INFO } from "@/config/contact";
+import { CONTACT_INFO, WHATSAPP_PRESET } from "@/config/contact";
 
 export default function WhatsAppWidget() {
+  const href = `https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent(WHATSAPP_PRESET)}`;
+
   return (
-    <a href={`https://wa.me/${CONTACT_INFO.whatsappDigits}`} target="_blank" rel="noopener noreferrer" className="whatsapp-widget bg-green-500 text-white w-16 h-16 rounded-full flex items-center justify-center shadow-lg">
+    <a href={href} target="_blank" rel="noopener noreferrer" className="whatsapp-widget bg-green-500 text-white w-16 h-16 rounded-full flex items-center justify-center shadow-lg">
       <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 24 24"><path d="M.057 24l1.687-6.163c-1.041-1.804-1.588-3.849-1.587-5.946.003-6.556 5.338-11.891 11.893-11.891 3.181.001 6.167 1.24 8.413 3.488 2.245 2.248 3.481 5.236 3.48 8.414-.003 6.557-5.338 11.892-11.894 11.892-1.99 0-3.902-.539-5.587-1.528l-6.191 1.686zM8.118 18.332c1.462.877 3.139 1.363 4.872 1.364 5.418 0 9.801-4.383 9.802-9.802-.001-5.419-4.384-9.802-9.802-9.802-5.418 0-9.801 4.383-9.802 9.802-.001 1.802.49 3.531 1.438 5.093l-1.018 3.725 3.809-1.021z" /></svg>
     </a>
   );
 }
-
 

--- a/web/config/contact.ts
+++ b/web/config/contact.ts
@@ -7,3 +7,6 @@ export const CONTACT_INFO = {
 } as const;
 
 
+export const WHATSAPP_PRESET = "Hi Pat, ";
+
+

--- a/web/config/contact.ts
+++ b/web/config/contact.ts
@@ -6,7 +6,9 @@ export const CONTACT_INFO = {
   email: "pat@patofalltrades.co.uk",
 } as const;
 
-
 export const WHATSAPP_PRESET = "Hi Pat, ";
+
+export const whatsappHref = (preset: string = WHATSAPP_PRESET): string =>
+  `https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent(preset)}`;
 
 

--- a/web/tests/e2e/mobile-cta-bar.spec.ts
+++ b/web/tests/e2e/mobile-cta-bar.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, devices, Page } from '@playwright/test'
 import { ensureMobile } from './utils/ensureMobile'
-import { CONTACT_INFO, WHATSAPP_PRESET } from '../../config/contact'
+import { CONTACT_INFO, whatsappHref } from '../../config/contact'
 
 test.use({ ...devices['iPhone 12'] })
 
@@ -49,10 +49,7 @@ test.describe('Mobile CTA Bar', () => {
 		await expect(whatsapp).toHaveAttribute('target', '_blank')
 		await expect(whatsapp).toHaveAttribute('rel', /noopener/)
 		await expect(whatsapp).toHaveAttribute('rel', /noreferrer/)
-		await expect(whatsapp).toHaveAttribute(
-			'href',
-			`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent(WHATSAPP_PRESET)}`
-		)
+		await expect(whatsapp).toHaveAttribute('href', whatsappHref())
 	})
 
 	test('visible focus rings on keyboard focus', async ({ page }) => {

--- a/web/tests/e2e/mobile-cta-bar.spec.ts
+++ b/web/tests/e2e/mobile-cta-bar.spec.ts
@@ -26,6 +26,7 @@ test.describe('Mobile CTA Bar', () => {
 
 	test('Get Quote scrolls to #contact and focuses first field', async ({ page }) => {
 		const getQuote = page.getByRole('link', { name: 'Get Quote' })
+		await expect(getQuote).toBeVisible()
 		await getQuote.click()
 		// Wait a tick for focus to move
 		const nameInput = page.locator('#name')
@@ -43,11 +44,24 @@ test.describe('Mobile CTA Bar', () => {
 		expect(box2?.height || 0).toBeGreaterThanOrEqual(44)
 	})
 
+	test('WhatsApp CTA opens chat in new tab with preset message', async ({ page }) => {
+		const whatsapp = page.getByRole('link', { name: 'WhatsApp' })
+		await expect(whatsapp).toHaveAttribute('target', '_blank')
+		await expect(whatsapp).toHaveAttribute('rel', /noopener|noreferrer/)
+		await expect(whatsapp).toHaveAttribute(
+			'href',
+			`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent('Hi Pat, ')}`
+		)
+	})
+
 	test('visible focus rings on keyboard focus', async ({ page }) => {
-		// Move focus into document then tab to CTA links
+		// Move focus into document then tab through CTA links
 		await page.focus('body')
 		const call = page.getByRole('link', { name: 'Call' })
 		await call.focus()
+		await page.keyboard.press('Tab')
+		const whatsapp = page.getByRole('link', { name: 'WhatsApp' })
+		await expect(whatsapp).toBeFocused()
 		await page.keyboard.press('Tab')
 		const getQuote = page.getByRole('link', { name: 'Get Quote' })
 		await expect(getQuote).toBeFocused()

--- a/web/tests/e2e/mobile-cta-bar.spec.ts
+++ b/web/tests/e2e/mobile-cta-bar.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, devices, Page } from '@playwright/test'
 import { ensureMobile } from './utils/ensureMobile'
-import { CONTACT_INFO, whatsappHref } from '../../config/contact'
+import { CONTACT_INFO, WHATSAPP_PRESET, whatsappHref } from '../../config/contact'
 
 test.use({ ...devices['iPhone 12'] })
 
@@ -15,17 +15,17 @@ test.describe('Mobile CTA Bar', () => {
 	test('renders on mobile view and shows buttons @smoke', async ({ page }) => {
 		const bar = page.getByRole('link', { name: 'Get Quote' })
 		await expect(bar).toBeVisible()
-		const call = page.getByRole('link', { name: 'Call' })
+		const call = page.locator('[data-testid="mobile-cta-link"][data-action="call"]')
 		await expect(call).toBeVisible()
 	})
 
 	test('tel link opens dialer scheme', async ({ page }) => {
-		const call = page.getByRole('link', { name: 'Call' })
+		const call = page.locator('[data-testid="mobile-cta-link"][data-action="call"]')
 		await expect(call).toHaveAttribute('href', `tel:${CONTACT_INFO.phoneE164}`)
 	})
 
 	test('Get Quote scrolls to #contact and focuses first field', async ({ page }) => {
-		const getQuote = page.getByRole('link', { name: 'Get Quote' })
+		const getQuote = page.locator('[data-testid="mobile-cta-link"][data-action="get-quote"]')
 		await expect(getQuote).toBeVisible()
 		await getQuote.click()
 		// Wait a tick for focus to move
@@ -36,32 +36,37 @@ test.describe('Mobile CTA Bar', () => {
 	})
 
 	test('buttons are at least 44px tall', async ({ page }) => {
-		const getQuote = page.getByRole('link', { name: 'Get Quote' })
+		const getQuote = page.locator('[data-testid="mobile-cta-link"][data-action="get-quote"]')
 		const box = await getQuote.boundingBox()
 		expect(box?.height || 0).toBeGreaterThanOrEqual(44)
-		const call = page.getByRole('link', { name: 'Call' })
+		const call = page.locator('[data-testid="mobile-cta-link"][data-action="call"]')
 		const box2 = await call.boundingBox()
 		expect(box2?.height || 0).toBeGreaterThanOrEqual(44)
 	})
 
 	test('WhatsApp CTA opens chat in new tab with preset message', async ({ page }) => {
-		const whatsapp = page.getByRole('link', { name: 'WhatsApp' })
+		const whatsapp = page.locator('[data-testid="mobile-cta-link"][data-action="whatsapp"]')
 		await expect(whatsapp).toHaveAttribute('target', '_blank')
 		await expect(whatsapp).toHaveAttribute('rel', /noopener/)
 		await expect(whatsapp).toHaveAttribute('rel', /noreferrer/)
 		await expect(whatsapp).toHaveAttribute('href', whatsappHref())
+		const rawHref = await whatsapp.getAttribute('href')
+		expect(rawHref).toBeTruthy()
+		const params = new URL(rawHref ?? '').searchParams
+		expect(params.get('text')).toBe(WHATSAPP_PRESET)
 	})
 
 	test('visible focus rings on keyboard focus', async ({ page }) => {
 		// Move focus into document then tab through CTA links
 		await page.focus('body')
-		const call = page.getByRole('link', { name: 'Call' })
+		const ctaLinks = page.getByTestId('mobile-cta-link')
+		const call = ctaLinks.nth(0)
 		await call.focus()
 		await page.keyboard.press('Tab')
-		const whatsapp = page.getByRole('link', { name: 'WhatsApp' })
+		const whatsapp = ctaLinks.nth(1)
 		await expect(whatsapp).toBeFocused()
 		await page.keyboard.press('Tab')
-		const getQuote = page.getByRole('link', { name: 'Get Quote' })
+		const getQuote = ctaLinks.nth(2)
 		await expect(getQuote).toBeFocused()
 		// Tailwind ring utilities apply via box-shadow when :focus-visible
 		const styles = await getQuote.evaluate(el => {

--- a/web/tests/e2e/mobile-cta-bar.spec.ts
+++ b/web/tests/e2e/mobile-cta-bar.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, devices, Page } from '@playwright/test'
 import { ensureMobile } from './utils/ensureMobile'
-import { CONTACT_INFO } from '../../config/contact'
+import { CONTACT_INFO, WHATSAPP_PRESET } from '../../config/contact'
 
 test.use({ ...devices['iPhone 12'] })
 
@@ -47,10 +47,11 @@ test.describe('Mobile CTA Bar', () => {
 	test('WhatsApp CTA opens chat in new tab with preset message', async ({ page }) => {
 		const whatsapp = page.getByRole('link', { name: 'WhatsApp' })
 		await expect(whatsapp).toHaveAttribute('target', '_blank')
-		await expect(whatsapp).toHaveAttribute('rel', /noopener|noreferrer/)
+		await expect(whatsapp).toHaveAttribute('rel', /noopener/)
+		await expect(whatsapp).toHaveAttribute('rel', /noreferrer/)
 		await expect(whatsapp).toHaveAttribute(
 			'href',
-			`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent('Hi Pat, ')}`
+			`https://wa.me/${CONTACT_INFO.whatsappDigits}?text=${encodeURIComponent(WHATSAPP_PRESET)}`
 		)
 	})
 

--- a/web/tests/e2e/smoke/hero-desktop.smoke.spec.ts
+++ b/web/tests/e2e/smoke/hero-desktop.smoke.spec.ts
@@ -12,7 +12,10 @@ test.describe('Smoke @smoke - Desktop hero CTA regression', () => {
     const heroGetQuote = hero.getByRole('link', { name: 'Get a Quote' })
     await expect(heroGetQuote).toHaveCount(0)
 
-    const headerQuote = page.getByRole('link', { name: 'Get a Quote' })
+    const headerQuote = page.locator('header').getByRole('link', { name: 'Get a Quote' })
     await expect(headerQuote.first()).toBeVisible()
+
+    const ax = await page.accessibility.snapshot()
+    expect(ax).toBeTruthy()
   })
 })

--- a/web/tests/e2e/smoke/hero-desktop.smoke.spec.ts
+++ b/web/tests/e2e/smoke/hero-desktop.smoke.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Smoke @smoke - Desktop hero CTA regression', () => {
+  test('Hero keeps View Portfolio as lone primary CTA', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await page.goto('/')
+
+    const hero = page.locator('main section').first()
+    const viewPortfolio = hero.getByRole('link', { name: 'View Portfolio' })
+    await expect(viewPortfolio).toBeVisible()
+
+    const heroGetQuote = hero.getByRole('link', { name: 'Get a Quote' })
+    await expect(heroGetQuote).toHaveCount(0)
+
+    const headerQuote = page.getByRole('link', { name: 'Get a Quote' })
+    await expect(headerQuote.first()).toBeVisible()
+  })
+})

--- a/web/tests/e2e/smoke/menu-contact-links.smoke.spec.ts
+++ b/web/tests/e2e/smoke/menu-contact-links.smoke.spec.ts
@@ -15,8 +15,8 @@ test.describe('Smoke @smoke - Contact links in menu drawer', () => {
     await expect(dialog).toBeVisible({ timeout: 10000 })
     // Allow menu animation to finish before querying links
     await page.waitForTimeout(300)
-    // Non-asserting snapshot for debugging per smoke guidelines
-    await page.accessibility.snapshot()
+    const ax = await page.accessibility.snapshot()
+    expect(ax).toBeTruthy()
     const axe = await new AxeBuilder({ page }).include('#mobile-menu-panel').withTags(['wcag2a','wcag2aa']).analyze()
     expect(axe.violations).toEqual([])
     await expect(dialog).toHaveAttribute('role', 'dialog')
@@ -39,5 +39,4 @@ test.describe('Smoke @smoke - Contact links in menu drawer', () => {
     await expect(email).toHaveAttribute('href', 'mailto:pat@patofalltrades.co.uk')
   })
 })
-
 

--- a/web/tests/e2e/smoke/menu-hamburger.smoke.spec.ts
+++ b/web/tests/e2e/smoke/menu-hamburger.smoke.spec.ts
@@ -13,8 +13,8 @@ test.describe('Smoke @smoke - Top hamburger opens bottom-sheet menu', () => {
     await hamburger.click()
     const dialog = page.locator('#mobile-menu-panel')
     await expect(dialog).toBeVisible()
-    // Non-asserting snapshot for debugging per smoke guidelines
-    await page.accessibility.snapshot()
+    const ax = await page.accessibility.snapshot()
+    expect(ax).toBeTruthy()
     const axe = await new AxeBuilder({ page }).include('#mobile-menu-panel').withTags(['wcag2a','wcag2aa']).analyze()
     expect(axe.violations).toEqual([])
 
@@ -26,5 +26,4 @@ test.describe('Smoke @smoke - Top hamburger opens bottom-sheet menu', () => {
     await expect(hamburger).toBeFocused()
   })
 })
-
 

--- a/web/tests/e2e/smoke/mobile-cta-menu.smoke.spec.ts
+++ b/web/tests/e2e/smoke/mobile-cta-menu.smoke.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test'
+
+const MOBILE_VIEWPORT = { width: 390, height: 844 }
+
+test.describe('Smoke @smoke - Mobile CTA bar coexists with menu', () => {
+  test('CTA bar stays visible while menu opens and closes', async ({ page }) => {
+    await page.setViewportSize(MOBILE_VIEWPORT)
+    await page.goto('/')
+
+    const ctaNav = page.getByRole('navigation', { name: 'Primary actions' })
+    await expect(ctaNav).toBeVisible()
+
+    const hamburger = page.getByTestId('header-hamburger')
+    await expect(hamburger).toBeVisible()
+    await hamburger.focus()
+    await page.keyboard.press('Enter')
+
+    const dialog = page.locator('#mobile-menu-panel')
+    await expect(dialog).toBeVisible()
+
+    // Close with Escape and confirm focus returns
+    await page.keyboard.press('Escape')
+    await expect(dialog).toBeHidden()
+    await expect(hamburger).toBeFocused()
+
+    // Scroll a bit after closing to ensure sticky CTA remains in view
+    await page.evaluate(() => window.scrollTo(0, 400))
+    await expect(ctaNav).toBeVisible()
+  })
+})

--- a/web/tests/e2e/smoke/mobile-cta-menu.smoke.spec.ts
+++ b/web/tests/e2e/smoke/mobile-cta-menu.smoke.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test'
 const MOBILE_VIEWPORT = { width: 390, height: 844 }
 
 test.describe('Smoke @smoke - Mobile CTA bar coexists with menu', () => {
-  test('CTA bar stays visible while menu opens and closes', async ({ page }) => {
+  test('CTA bar visible before open and after close', async ({ page }) => {
     await page.setViewportSize(MOBILE_VIEWPORT)
     await page.goto('/')
 
@@ -26,5 +26,8 @@ test.describe('Smoke @smoke - Mobile CTA bar coexists with menu', () => {
     // Scroll a bit after closing to ensure sticky CTA remains in view
     await page.evaluate(() => window.scrollTo(0, 400))
     await expect(ctaNav).toBeVisible()
+
+    const ax = await page.accessibility.snapshot()
+    expect(ax).toBeTruthy()
   })
 })

--- a/web/tests/e2e/smoke/smart-scroll.spec.ts
+++ b/web/tests/e2e/smoke/smart-scroll.spec.ts
@@ -9,22 +9,6 @@ test.describe('Smart Scroll Behavior @smoke', () => {
     await page.waitForLoadState('networkidle')
     await page.evaluate(() => {
       window.scrollTo({ top: 0, behavior: 'auto' })
-      const ensureScrollSpace = () => {
-        if (document.documentElement.scrollHeight > window.innerHeight) return true
-        const fillerId = 'smart-scroll-filler'
-        let filler = document.getElementById(fillerId)
-        if (!filler) {
-          filler = document.createElement('div')
-          filler.id = fillerId
-          filler.setAttribute('data-testid', fillerId)
-          filler.style.height = '200vh'
-          filler.style.width = '1px'
-          document.body.appendChild(filler)
-        }
-        document.documentElement.style.minHeight = '200vh'
-        return document.documentElement.scrollHeight > window.innerHeight
-      }
-      ensureScrollSpace()
     })
     await expect.poll(
       async () => page.evaluate(() => document.documentElement.scrollHeight > window.innerHeight),
@@ -36,8 +20,6 @@ test.describe('Smart Scroll Behavior @smoke', () => {
 
     // Ensure initial state not hidden
     await expect(header).not.toHaveClass(/sticky-nav--hidden/)
-
-    await page.mouse.move(120, 120)
 
     // Scroll down to trigger hide
     await page.mouse.wheel(0, 900)
@@ -66,9 +48,9 @@ test.describe('Smart Scroll Behavior @smoke', () => {
     await cta.waitFor({ state: 'visible', timeout: 5000 })
     await page.mouse.wheel(0, 400)
     await expect.poll(
-      async () => cta.evaluate((el) => el.classList.contains('bottom-cta--shadow')),
+      async () => cta.getAttribute('data-shadowed'),
       { message: 'CTA should gain shadow after scrolling', intervals: [50, 100, 150, 250], timeout: 1500 }
-    ).toBeTruthy()
+    ).toBe('true')
     // Scroll to top, shadow can disappear
     await page.mouse.wheel(0, -400)
     await expect.poll(
@@ -76,9 +58,9 @@ test.describe('Smart Scroll Behavior @smoke', () => {
       { message: 'return to top before checking CTA shadow clears', intervals: [50, 100, 150, 250], timeout: 1500 }
     ).toBeTruthy()
     await expect.poll(
-      async () => cta.evaluate((el) => el.classList.contains('bottom-cta--shadow')),
+      async () => cta.getAttribute('data-shadowed'),
       { message: 'CTA shadow should clear near top', intervals: [50, 100, 150, 250], timeout: 2000 }
-    ).toBeFalsy()
+    ).toBe('false')
 
     // Basic a11y snapshot capture to ensure no crash
     const ax = await page.accessibility.snapshot()

--- a/web/tests/e2e/smoke/smart-scroll.spec.ts
+++ b/web/tests/e2e/smoke/smart-scroll.spec.ts
@@ -14,22 +14,31 @@ test.describe('Smart Scroll Behavior @smoke', () => {
 
     // Scroll down to trigger hide
     await page.evaluate(() => window.scrollTo({ top: 800, behavior: 'auto' }))
-    await page.waitForTimeout(200)
-    await expect(header).toHaveClass(/sticky-nav--hidden/, { timeout: 15000 })
+    await expect.poll(
+      async () => header.evaluate((el) => el.classList.contains('sticky-nav--hidden')),
+      { message: 'header should hide after scrolling down', intervals: [50, 100, 150, 250], timeout: 1500 }
+    ).toBeTruthy()
 
     // Scroll up to trigger show (with 100ms debounce)
     await page.evaluate(() => window.scrollTo({ top: 100, behavior: 'auto' }))
-    await page.waitForTimeout(200)
-    await expect(header).not.toHaveClass(/sticky-nav--hidden/, { timeout: 15000 })
+    await expect.poll(
+      async () => header.evaluate((el) => el.classList.contains('sticky-nav--hidden')),
+      { message: 'header should reappear after scrolling up', intervals: [50, 100, 150, 250], timeout: 1500 }
+    ).toBeFalsy()
 
     // Bottom CTA bar shadow when scrolled
     const cta = page.locator('nav[aria-label="Primary actions"]')
     await cta.waitFor({ state: 'visible', timeout: 5000 })
-    await expect(cta).toHaveClass(/bottom-cta--shadow/, { timeout: 15000 })
+    await expect.poll(
+      async () => cta.evaluate((el) => el.classList.contains('bottom-cta--shadow')),
+      { message: 'CTA should gain shadow after scrolling', intervals: [50, 100, 150, 250], timeout: 1500 }
+    ).toBeTruthy()
     // Scroll to top, shadow can disappear
     await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'auto' }))
-    await page.waitForTimeout(500)
-    await expect(cta).not.toHaveClass(/bottom-cta--shadow/, { timeout: 15000 })
+    await expect.poll(
+      async () => cta.evaluate((el) => el.classList.contains('bottom-cta--shadow')),
+      { message: 'CTA shadow should clear near top', intervals: [50, 100, 150, 250], timeout: 2000 }
+    ).toBeFalsy()
 
     // Basic a11y snapshot capture to ensure no crash
     const ax = await page.accessibility.snapshot()

--- a/web/tests/e2e/smoke/smart-scroll.spec.ts
+++ b/web/tests/e2e/smoke/smart-scroll.spec.ts
@@ -14,10 +14,12 @@ test.describe('Smart Scroll Behavior @smoke', () => {
 
     // Scroll down to trigger hide
     await page.evaluate(() => window.scrollTo({ top: 800, behavior: 'auto' }))
+    await page.waitForTimeout(200)
     await expect(header).toHaveClass(/sticky-nav--hidden/, { timeout: 15000 })
 
     // Scroll up to trigger show (with 100ms debounce)
     await page.evaluate(() => window.scrollTo({ top: 100, behavior: 'auto' }))
+    await page.waitForTimeout(200)
     await expect(header).not.toHaveClass(/sticky-nav--hidden/, { timeout: 15000 })
 
     // Bottom CTA bar shadow when scrolled
@@ -35,4 +37,3 @@ test.describe('Smart Scroll Behavior @smoke', () => {
   })
 })
  
-

--- a/web/tests/e2e/smoke/smart-scroll.spec.ts
+++ b/web/tests/e2e/smoke/smart-scroll.spec.ts
@@ -4,7 +4,32 @@ test.describe('Smart Scroll Behavior @smoke', () => {
   // Ensure mobile layout so MobileCtaBar is visible (md:hidden on desktop)
   test.use({ viewport: { width: 390, height: 844 } })
   test('header hides on scroll down, shows on scroll up; bottom CTA shadow toggles', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' })
     await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page.evaluate(() => {
+      window.scrollTo({ top: 0, behavior: 'auto' })
+      const ensureScrollSpace = () => {
+        if (document.documentElement.scrollHeight > window.innerHeight) return true
+        const fillerId = 'smart-scroll-filler'
+        let filler = document.getElementById(fillerId)
+        if (!filler) {
+          filler = document.createElement('div')
+          filler.id = fillerId
+          filler.setAttribute('data-testid', fillerId)
+          filler.style.height = '200vh'
+          filler.style.width = '1px'
+          document.body.appendChild(filler)
+        }
+        document.documentElement.style.minHeight = '200vh'
+        return document.documentElement.scrollHeight > window.innerHeight
+      }
+      ensureScrollSpace()
+    })
+    await expect.poll(
+      async () => page.evaluate(() => document.documentElement.scrollHeight > window.innerHeight),
+      { message: 'ensure page has scrollable height for smart header behavior', intervals: [50, 100, 150, 250], timeout: 1500 }
+    ).toBeTruthy()
 
     const header = page.locator('#navbar')
     await expect(header).toBeVisible()
@@ -12,15 +37,25 @@ test.describe('Smart Scroll Behavior @smoke', () => {
     // Ensure initial state not hidden
     await expect(header).not.toHaveClass(/sticky-nav--hidden/)
 
+    await page.mouse.move(120, 120)
+
     // Scroll down to trigger hide
-    await page.evaluate(() => window.scrollTo({ top: 800, behavior: 'auto' }))
+    await page.mouse.wheel(0, 900)
+    await expect.poll(
+      async () => page.evaluate(() => window.scrollY),
+      { message: 'should move far enough down the page', intervals: [50, 100, 150, 250], timeout: 1500 }
+    ).toBeGreaterThan(400)
     await expect.poll(
       async () => header.evaluate((el) => el.classList.contains('sticky-nav--hidden')),
       { message: 'header should hide after scrolling down', intervals: [50, 100, 150, 250], timeout: 1500 }
     ).toBeTruthy()
 
     // Scroll up to trigger show (with 100ms debounce)
-    await page.evaluate(() => window.scrollTo({ top: 100, behavior: 'auto' }))
+    await page.mouse.wheel(0, -900)
+    await expect.poll(
+      async () => page.evaluate(() => window.scrollY),
+      { message: 'should scroll back near the top', intervals: [50, 100, 150, 250], timeout: 1500 }
+    ).toBeLessThan(200)
     await expect.poll(
       async () => header.evaluate((el) => el.classList.contains('sticky-nav--hidden')),
       { message: 'header should reappear after scrolling up', intervals: [50, 100, 150, 250], timeout: 1500 }
@@ -29,12 +64,17 @@ test.describe('Smart Scroll Behavior @smoke', () => {
     // Bottom CTA bar shadow when scrolled
     const cta = page.locator('nav[aria-label="Primary actions"]')
     await cta.waitFor({ state: 'visible', timeout: 5000 })
+    await page.mouse.wheel(0, 400)
     await expect.poll(
       async () => cta.evaluate((el) => el.classList.contains('bottom-cta--shadow')),
       { message: 'CTA should gain shadow after scrolling', intervals: [50, 100, 150, 250], timeout: 1500 }
     ).toBeTruthy()
     // Scroll to top, shadow can disappear
-    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'auto' }))
+    await page.mouse.wheel(0, -400)
+    await expect.poll(
+      async () => page.evaluate(() => window.scrollY <= 2),
+      { message: 'return to top before checking CTA shadow clears', intervals: [50, 100, 150, 250], timeout: 1500 }
+    ).toBeTruthy()
     await expect.poll(
       async () => cta.evaluate((el) => el.classList.contains('bottom-cta--shadow')),
       { message: 'CTA shadow should clear near top', intervals: [50, 100, 150, 250], timeout: 2000 }

--- a/web/tests/e2e/smoke/template.smoke.spec.ts
+++ b/web/tests/e2e/smoke/template.smoke.spec.ts
@@ -1,7 +1,9 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test'
 
 test.describe('Smoke Test - Template', () => {
-  test('Critical path verification', () => {
-    expect(true).toBeTruthy();
-  });
-});
+  test.skip('Example placeholder (replace with real smoke)', async ({ page }) => {
+    await page.goto('/')
+    const ax = await page.accessibility.snapshot()
+    expect(ax).toBeTruthy()
+  })
+})


### PR DESCRIPTION
This PR optimizes the bottom CTA experience on mobile and adds smoke coverage.

- Refines CTA layout for smaller screens
- Adds Playwright smoke tests:
  - `web/tests/e2e/smoke/hero-desktop.smoke.spec.ts`
  - `web/tests/e2e/smoke/mobile-cta-menu.smoke.spec.ts`


Implements ticket https://github.com/tonym999/patofalltrades/issues/28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hero CTA simplified to a single "View Portfolio"; "Get a Quote" retained in header.
  * WhatsApp CTA now opens chat with a configurable preset message.

* **Style**
  * Mobile CTA bar redesigned with icons, translucent pill buttons, updated spacing, colors, hover/focus effects.
  * Increased layering/z-index for header and modals; background interaction disabled for parallax.

* **Bug Fixes**
  * Improved focus restoration for mobile menu; safer resize observer handling.

* **Tests**
  * Added/updated smoke and e2e tests covering hero CTAs, mobile CTA/menu, WhatsApp, and resilient scrolling/assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->