### PR TITLE
Add hero scrim overlay contrast smoke test

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -31,6 +31,7 @@
     --bg-950: hsl(var(--background-end));
     --accent: hsl(var(--primary));
     --accent-strong: hsl(31 91% 55%);
+    --hero-scrim: 221 55% 10%;
 
     /* Compatibility tokens */
     --gold: var(--accent);
@@ -76,6 +77,7 @@
     --bg-950: hsl(var(--background-end));
     --accent: hsl(var(--primary));
     --accent-strong: hsl(31 91% 55%);
+    --hero-scrim: 221 45% 8%;
 
     /* Compatibility tokens */
     --gold: var(--accent);

--- a/web/components/EnhancedHero.tsx
+++ b/web/components/EnhancedHero.tsx
@@ -45,10 +45,14 @@ export function EnhancedHero({ children }: EnhancedHeroProps) {
             fill
             sizes="100vw"
             priority
-            className="object-cover"
+            className="object-cover filter brightness-110 saturate-110"
           />
         </div>
-        <div className="absolute inset-0 bg-gradient-to-br from-slate-900/80 via-slate-800/60 to-slate-900/80" />
+        <div
+          className="absolute inset-0 bg-[hsl(var(--hero-scrim))]/70"
+          aria-hidden="true"
+          data-testid="hero-overlay"
+        />
       </motion.div>
 
       {/* Floating Tools */}

--- a/web/tests/e2e/hero-contrast.spec.ts
+++ b/web/tests/e2e/hero-contrast.spec.ts
@@ -75,6 +75,8 @@ test.describe('Hero contrast @smoke', () => {
         canvas.width = heroImage.naturalWidth
         canvas.height = heroImage.naturalHeight
         const ctx = canvas.getContext('2d')!
+        const computedFilter = getComputedStyle(heroImage).filter
+        ctx.filter = computedFilter && computedFilter !== 'none' ? computedFilter : 'none'
         ctx.drawImage(heroImage, 0, 0, heroImage.naturalWidth, heroImage.naturalHeight)
         const pixel = ctx.getImageData(
           Math.round(normalizedX * (heroImage.naturalWidth - 1)),

--- a/web/tests/e2e/hero-contrast.spec.ts
+++ b/web/tests/e2e/hero-contrast.spec.ts
@@ -18,6 +18,10 @@ test.describe('Hero contrast @smoke', () => {
     await expect(heroHeading).toBeVisible()
     await expect(heroSubtitle).toBeVisible()
 
+    const accessibilityTree = await page.accessibility.snapshot()
+    const accessibilitySnapshot = JSON.stringify(accessibilityTree, null, 2)
+    expect(accessibilitySnapshot).toMatchSnapshot('hero-accessibility.json')
+
     const contrastOf = async (locator: import('@playwright/test').Locator) => {
       return locator.evaluate(element => {
         const toLinear = (channel: number): number => {

--- a/web/tests/e2e/hero-contrast.spec.ts
+++ b/web/tests/e2e/hero-contrast.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from '@playwright/test'
+
+const MIN_CONTRAST = 4.5
+
+test.describe('Hero contrast @smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForFunction(() => {
+      const img = document.querySelector('img[alt="Handyman hero background"]') as HTMLImageElement | null
+      return Boolean(img && img.complete && img.naturalWidth > 0 && img.naturalHeight > 0)
+    })
+  })
+
+  test('hero heading and subtitle meet WCAG contrast', async ({ page }) => {
+    const heroHeading = page.getByRole('heading', { level: 1, name: /london's premier handyman/i })
+    const heroSubtitle = page.getByText(/reliable\. professional\. unmatched quality\./i)
+
+    await expect(heroHeading).toBeVisible()
+    await expect(heroSubtitle).toBeVisible()
+
+    const contrastOf = async (locator: import('@playwright/test').Locator) => {
+      return locator.evaluate(element => {
+        const toLinear = (channel: number): number => {
+          const normalized = channel / 255
+          return normalized <= 0.03928 ? normalized / 12.92 : Math.pow((normalized + 0.055) / 1.055, 2.4)
+        }
+
+        const luminance = (r: number, g: number, b: number): number => {
+          return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b)
+        }
+
+        const parseCssColor = (cssColor: string): [number, number, number, number] => {
+          const canvas = document.createElement('canvas')
+          canvas.width = canvas.height = 1
+          const ctx = canvas.getContext('2d')!
+          ctx.clearRect(0, 0, 1, 1)
+          ctx.fillStyle = cssColor
+          ctx.fillRect(0, 0, 1, 1)
+          const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data as unknown as [number, number, number, number]
+          return [r, g, b, a / 255]
+        }
+
+        const clamp01 = (value: number): number => Math.min(0.999999, Math.max(0, value))
+
+        const textRgb = parseCssColor(getComputedStyle(element).color)
+
+        const rect = element.getBoundingClientRect()
+        const sampleX = rect.left + rect.width / 2
+        const sampleY = rect.top + rect.height / 2
+
+        const heroImage = document.querySelector('img[alt="Handyman hero background"]') as HTMLImageElement | null
+        if (!heroImage || !heroImage.naturalWidth || !heroImage.naturalHeight) {
+          throw new Error('Hero image is not ready for sampling')
+        }
+
+        const imageRect = heroImage.getBoundingClientRect()
+        if (imageRect.width === 0 || imageRect.height === 0) {
+          throw new Error('Hero image has zero-sized client rect')
+        }
+
+        const scale = Math.max(imageRect.width / heroImage.naturalWidth, imageRect.height / heroImage.naturalHeight)
+        const displayedWidth = heroImage.naturalWidth * scale
+        const displayedHeight = heroImage.naturalHeight * scale
+        const offsetX = (displayedWidth - imageRect.width) / 2
+        const offsetY = (displayedHeight - imageRect.height) / 2
+
+        const normalizedX = clamp01((sampleX - imageRect.left + offsetX) / displayedWidth)
+        const normalizedY = clamp01((sampleY - imageRect.top + offsetY) / displayedHeight)
+
+        const canvas = document.createElement('canvas')
+        canvas.width = heroImage.naturalWidth
+        canvas.height = heroImage.naturalHeight
+        const ctx = canvas.getContext('2d')!
+        ctx.drawImage(heroImage, 0, 0, heroImage.naturalWidth, heroImage.naturalHeight)
+        const pixel = ctx.getImageData(
+          Math.round(normalizedX * (heroImage.naturalWidth - 1)),
+          Math.round(normalizedY * (heroImage.naturalHeight - 1)),
+          1,
+          1,
+        ).data
+
+        let backgroundRgb: [number, number, number] = [pixel[0], pixel[1], pixel[2]]
+
+        const overlay = document.querySelector('[data-testid="hero-overlay"]') as HTMLElement | null
+        if (overlay) {
+          const [or, og, ob, oa] = parseCssColor(getComputedStyle(overlay).backgroundColor)
+          const alpha = clamp01(oa)
+          backgroundRgb = [
+            or * alpha + backgroundRgb[0] * (1 - alpha),
+            og * alpha + backgroundRgb[1] * (1 - alpha),
+            ob * alpha + backgroundRgb[2] * (1 - alpha),
+          ]
+        }
+
+        const textLuminance = luminance(textRgb[0], textRgb[1], textRgb[2])
+        const backgroundLuminance = luminance(backgroundRgb[0], backgroundRgb[1], backgroundRgb[2])
+
+        const lighter = Math.max(textLuminance, backgroundLuminance)
+        const darker = Math.min(textLuminance, backgroundLuminance)
+        return Number(((lighter + 0.05) / (darker + 0.05)).toFixed(2))
+      })
+    }
+
+    const headingContrast = await contrastOf(heroHeading)
+    expect(headingContrast).toBeGreaterThanOrEqual(MIN_CONTRAST)
+
+    const subtitleContrast = await contrastOf(heroSubtitle)
+    expect(subtitleContrast).toBeGreaterThanOrEqual(MIN_CONTRAST)
+  })
+})

--- a/web/tests/e2e/hero-contrast.spec.ts-snapshots/hero-accessibility-chromium-linux.json
+++ b/web/tests/e2e/hero-contrast.spec.ts-snapshots/hero-accessibility-chromium-linux.json
@@ -1,0 +1,343 @@
+{
+  "role": "WebArea",
+  "name": "Pat Of All Trades | Premium London Handyman Services",
+  "children": [
+    {
+      "role": "link",
+      "name": "Skip to main content"
+    },
+    {
+      "role": "link",
+      "name": "Pat Of All Trades logo Pat Of All Trades"
+    },
+    {
+      "role": "link",
+      "name": "Services"
+    },
+    {
+      "role": "link",
+      "name": "Portfolio"
+    },
+    {
+      "role": "link",
+      "name": "About"
+    },
+    {
+      "role": "link",
+      "name": "Testimonials"
+    },
+    {
+      "role": "link",
+      "name": "Get a Quote"
+    },
+    {
+      "role": "main",
+      "name": "",
+      "children": [
+        {
+          "role": "image",
+          "name": "Handyman hero background"
+        },
+        {
+          "role": "heading",
+          "name": "LONDON'S PREMIER HANDYMAN",
+          "level": 1
+        },
+        {
+          "role": "text",
+          "name": "Reliable. Professional. Unmatched Quality."
+        },
+        {
+          "role": "link",
+          "name": "View Portfolio"
+        },
+        {
+          "role": "heading",
+          "name": "Our Services",
+          "level": 2
+        },
+        {
+          "role": "text",
+          "name": "Comprehensive handyman services delivered with precision, professionalism, and pride. No job too big or small."
+        },
+        {
+          "role": "group",
+          "name": "General Repairs"
+        },
+        {
+          "role": "group",
+          "name": "Painting & Decorating"
+        },
+        {
+          "role": "group",
+          "name": "Electrical Work"
+        },
+        {
+          "role": "group",
+          "name": "Plumbing Services"
+        },
+        {
+          "role": "heading",
+          "name": "Our Work",
+          "level": 2
+        },
+        {
+          "role": "text",
+          "name": "Quality you can see. Results that last."
+        },
+        {
+          "role": "heading",
+          "name": "Bedroom: Southwark #001",
+          "level": 3
+        },
+        {
+          "role": "image",
+          "name": "bedroom in southwark (before)"
+        },
+        {
+          "role": "image",
+          "name": "bedroom in southwark (after)"
+        },
+        {
+          "role": "slider",
+          "name": "Reveal after photo width",
+          "valuetext": "",
+          "valuemin": 0,
+          "valuemax": 100,
+          "orientation": "horizontal",
+          "value": 50
+        },
+        {
+          "role": "heading",
+          "name": "Stairs: Colindale #001",
+          "level": 3
+        },
+        {
+          "role": "image",
+          "name": "stairs in colindale (before)"
+        },
+        {
+          "role": "image",
+          "name": "stairs in colindale (after)"
+        },
+        {
+          "role": "text",
+          "name": "↔"
+        },
+        {
+          "role": "heading",
+          "name": "Our Service Area",
+          "level": 2
+        },
+        {
+          "role": "text",
+          "name": "Proudly serving North West London and surrounding areas. We are based in Colindale and our core service areas include:"
+        },
+        {
+          "role": "text",
+          "name": "Barnet"
+        },
+        {
+          "role": "text",
+          "name": "Brent"
+        },
+        {
+          "role": "text",
+          "name": "Harrow"
+        },
+        {
+          "role": "text",
+          "name": "Camden"
+        },
+        {
+          "role": "text",
+          "name": "Hendon"
+        },
+        {
+          "role": "text",
+          "name": "Edgware"
+        },
+        {
+          "role": "text",
+          "name": "Don't see your area? Contact us to see if we cover your postcode!"
+        },
+        {
+          "role": "heading",
+          "name": "About Us",
+          "level": 2
+        },
+        {
+          "role": "text",
+          "name": "A decade of dedication to London homes."
+        },
+        {
+          "role": "image",
+          "name": "Craftsman"
+        },
+        {
+          "role": "text",
+          "name": "Founded in 2014, Pat Of All Trades was born from a simple mission: to provide Londoners with a handyman service that is not just reliable, but remarkably professional. We believe in clear communication, transparent pricing, and a finished product that exceeds expectations every time."
+        },
+        {
+          "role": "text",
+          "name": "0"
+        },
+        {
+          "role": "text",
+          "name": "Years Experience"
+        },
+        {
+          "role": "text",
+          "name": "0"
+        },
+        {
+          "role": "text",
+          "name": "Jobs Completed"
+        },
+        {
+          "role": "region",
+          "name": "Client testimonials",
+          "children": [
+            {
+              "role": "text",
+              "name": "Slide 1 of 4"
+            },
+            {
+              "role": "heading",
+              "name": "What Clients Say",
+              "level": 2
+            },
+            {
+              "role": "text",
+              "name": "Don't just take our word for it. Here's what our satisfied clients across London have to say."
+            },
+            {
+              "role": "tabpanel",
+              "name": "Show testimonial 1: Sarah Johnson from Kensington",
+              "children": [
+                {
+                  "role": "generic",
+                  "name": "",
+                  "children": [
+                    {
+                      "role": "image",
+                      "name": "Rated 5 out of 5",
+                      "description": "Rated 5 out of 5"
+                    },
+                    {
+                      "role": "text",
+                      "name": "Absolutely outstanding service. Pat was punctual, professional, and the quality of his work was second to none. He transformed our flat. Highly recommended!"
+                    },
+                    {
+                      "role": "text",
+                      "name": "Sarah Johnson"
+                    },
+                    {
+                      "role": "text",
+                      "name": " – "
+                    },
+                    {
+                      "role": "text",
+                      "name": "Kitchen Renovation"
+                    },
+                    {
+                      "role": "text",
+                      "name": "Location:"
+                    },
+                    {
+                      "role": "text",
+                      "name": "Kensington"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "role": "tab",
+              "name": "Show testimonial 1: Sarah Johnson from Kensington",
+              "selected": true
+            },
+            {
+              "role": "tab",
+              "name": "Show testimonial 2: Michael Chen from Camden"
+            },
+            {
+              "role": "tab",
+              "name": "Show testimonial 3: Emma Williams from Shoreditch"
+            },
+            {
+              "role": "tab",
+              "name": "Show testimonial 4: James Thompson from Chelsea"
+            }
+          ]
+        },
+        {
+          "role": "heading",
+          "name": "Get In Touch",
+          "level": 2
+        },
+        {
+          "role": "text",
+          "name": "Ready to start your next project? Let's talk."
+        },
+        {
+          "role": "text",
+          "name": "Name"
+        },
+        {
+          "role": "textbox",
+          "name": "Name",
+          "required": true
+        },
+        {
+          "role": "text",
+          "name": "Email"
+        },
+        {
+          "role": "textbox",
+          "name": "Email",
+          "required": true
+        },
+        {
+          "role": "text",
+          "name": "Phone (optional)"
+        },
+        {
+          "role": "textbox",
+          "name": "Phone (optional)"
+        },
+        {
+          "role": "text",
+          "name": "Message"
+        },
+        {
+          "role": "text",
+          "name": "Tell us about your project, timeline, and any specifics you'd like us to consider. Maximum 5000 characters."
+        },
+        {
+          "role": "textbox",
+          "name": "Message",
+          "description": "Tell us about your project, timeline, and any specifics you'd like us to consider. Maximum 5000 characters.",
+          "multiline": true,
+          "required": true
+        },
+        {
+          "role": "button",
+          "name": "Send Message"
+        }
+      ]
+    },
+    {
+      "role": "text",
+      "name": "© 2024 Pat Of All Trades. All Rights Reserved."
+    },
+    {
+      "role": "text",
+      "name": "Premium Handyman Services in London"
+    },
+    {
+      "role": "link",
+      "name": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add hero overlay sourced from theme token and brighten base image
- define hero scrim tokens for light and dark palettes
- add smoke test verifying hero heading/subtitle contrast

## Testing
- pnpm test:e2e:smoke

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Improved hero visuals with a new HSL scrim overlay and tuned image rendering for enhanced readability.
  - Added light/dark scrim variables to maintain consistent contrast across themes.

- Tests
  - Added an end-to-end test verifying hero heading and subtitle meet WCAG contrast thresholds, accounting for overlay and imagery.
  - Added an accessibility snapshot of the hero page for automated verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->