### PR TITLE
fix(lint): resolve set-state-in-effect debt

### DIFF
--- a/web/components/ClientOnly.tsx
+++ b/web/components/ClientOnly.tsx
@@ -1,16 +1,19 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 type ClientOnlyProps = {
   children: React.ReactNode;
 };
 
+const subscribe = () => () => {};
+const getSnapshot = () => true;
+const getServerSnapshot = () => false;
+
 export default function ClientOnly({ children }: ClientOnlyProps) {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  const mounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
   if (!mounted) return null;
   return <>{children}</>;
 }
-
 

--- a/web/components/Testimonials.tsx
+++ b/web/components/Testimonials.tsx
@@ -21,13 +21,13 @@ export default function Testimonials() {
   const [isInView, setIsInView] = useState(false);
   const [isDocumentVisible, setIsDocumentVisible] = useState(true);
   const [isUserPaused, setIsUserPaused] = useState(false);
-  const [liveAnnouncement, setLiveAnnouncement] = useState("");
 
   const testimonials = testimonialsData;
   const total = testimonials.length;
   const idPrefix = useId();
   const tabPanelId = `${idPrefix}-tabpanel`;
   const getTabId = (index: number) => `${idPrefix}-tab-${index}`;
+  const liveAnnouncement = total ? `Slide ${currentIndex + 1} of ${total}` : "";
 
   useEffect(() => {
     const observeTarget = sectionRef.current;
@@ -77,11 +77,6 @@ export default function Testimonials() {
       if (autoplayIntervalRef.current) window.clearInterval(autoplayIntervalRef.current);
     };
   }, []);
-
-  useEffect(() => {
-    if (!total) return;
-    setLiveAnnouncement(`Slide ${currentIndex + 1} of ${total}`);
-  }, [currentIndex, total]);
 
   type GoToOptions = {
     pauseForMs?: number;


### PR DESCRIPTION
## Summary

Fixes the existing repo-wide `react-hooks/set-state-in-effect` lint debt called out in #116.
The client-only mount guard now uses a server/client snapshot instead of an effect-driven state update, and the testimonials live region announcement is derived directly from the active slide state.

## Linked Issue

Closes #116

## Validation Against Issue

This PR updates the two components named in the issue without adding any lint suppressions or changing ESLint configuration. `ClientOnly.tsx` no longer calls `setState` from `useEffect`, `Testimonials.tsx` no longer updates announcement state from an effect, and the resulting behavior remains intact while removing the blocking repo-wide lint errors.

## Changes

- Replace the `ClientOnly` mount effect with `useSyncExternalStore` using explicit server/client snapshots.
- Remove the `Testimonials` live announcement state and compute the announcement string from `currentIndex` and `total`.
- Validate the change with a full lint run, production build, and smoke suite.

## Testing

- [ ] Not run
- [ ] Docs-only / Not applicable
- [x] `pnpm run lint` (from `web/`)
- [x] `pnpm run test:e2e:smoke` (from `web/`)
- [x] Other: `pnpm exec next build` (from `web/`)

## Risks

- User-facing impact: Low. The changes preserve the existing render and announcement behavior while removing unnecessary effect-driven state updates.
- Rollback plan: Revert this PR to restore the previous implementations in `ClientOnly.tsx` and `Testimonials.tsx`.

## Screenshots / Evidence

N/A

## Checklist

- [x] The PR is scoped to one main objective
- [x] The linked issue is specific and up to date
- [x] The PR description uses the same terminology as the issue
- [x] Acceptance criteria are covered or explicitly called out as not done
- [x] New docs or workflow changes are reflected in repo documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimised component mounting logic for improved performance.
  * Refined accessibility announcement updates for better efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->