### PR TITLE
Add repo-defined Playwright skill

### DIFF
--- a/.cursor/skills/playwright/SKILL.md
+++ b/.cursor/skills/playwright/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: playwright
+description: Run or debug Playwright work in this repo, including choosing between repo E2E tests and ad hoc browser automation, bootstrapping Node and pnpm from `web/`, and storing artifacts using the repo's existing conventions.
+---
+
+# Playwright
+
+## When to use
+- Running or updating Playwright coverage under `web/tests/e2e/`
+- Debugging a UI flow in a real browser before deciding whether a repo test is needed
+- Reproducing a bug, collecting screenshots, or capturing traces for a ticket or PR
+- Validating a UI change with the repo's smoke or accessibility suites
+
+## Choose the right path
+- Use repo tests when the behavior should be repeatable, CI-covered, or committed with the ticket.
+- Use ad hoc browser automation when exploring a flow, reproducing a bug, or gathering one-off evidence.
+- Default post-change validation in this repo is `pnpm run test:e2e:smoke` from `web/`.
+- If the change is accessibility-critical, also run `pnpm run test:e2e:a11y`.
+- Do not add new E2E coverage unless the ticket needs lasting regression protection.
+
+## Repo layout
+- Run package-manager and Playwright commands from `web/` so Corepack uses the pinned `pnpm` version.
+- Playwright config lives at `web/playwright.config.ts`.
+- Tests live under `web/tests/e2e/` with `smoke/`, `functional/`, `fixtures/`, and `utils/`.
+- Local test runs use `pnpm run start:test` on port `3000` unless `BASE_URL` is set.
+
+## Bootstrap
+1. From the repo root, load Node with `source "$HOME/.nvm/nvm.sh" && nvm use`.
+2. Change into `web/`.
+3. Run `pnpm install`.
+4. If Playwright browsers are missing, run `pnpm exec playwright install` locally or `pnpm exec playwright install --with-deps` on Linux/CI.
+
+## Common commands
+- Smoke suite: `pnpm run test:e2e:smoke`
+- Full suite: `pnpm run test:e2e`
+- Accessibility baseline: `pnpm run test:e2e:a11y`
+- Single spec: `pnpm exec playwright test tests/e2e/smoke/logo.smoke.spec.ts`
+- Filter by title or tag: `pnpm exec playwright test --grep "menu"`
+- Interactive runner: `pnpm run test:e2e:ui`
+- Reuse an existing server: `BASE_URL=http://127.0.0.1:3000 pnpm run test:e2e`
+
+## Authoring and maintenance
+- Put durable happy-path coverage in `web/tests/e2e/smoke/*.smoke.spec.ts` and keep the `@smoke` tag so the default smoke command picks it up.
+- Put deeper behavior-specific coverage in `web/tests/e2e/functional/`.
+- Reuse helpers from `web/tests/e2e/fixtures/` and `web/tests/e2e/utils/` before adding new setup code.
+- Include a basic accessibility check in at least one critical-path test.
+- In sandboxed Linux environments, prefer Axe or DOM-level assertions over `page.accessibility.snapshot()` unless you have already confirmed snapshot calls are stable here.
+
+## Artifact conventions
+- `@playwright/test` already keeps failure traces, videos, and screenshots under `web/test-results/` because `web/playwright.config.ts` uses `retain-on-failure` and `only-on-failure`.
+- HTML reports live in `web/playwright-report/` and can be opened with `pnpm run test:e2e:report`.
+- For ad hoc browser automation outside the test runner, place screenshots, traces, and notes under `web/test-results/manual/<ticket-or-date>/` so they stay untracked with the repo's existing ignore rules.
+- Clean up one-off artifacts when the ticket is done unless they are still needed for review.
+
+## Ad hoc browser automation
+- If your agent environment exposes a Playwright CLI or browser automation wrapper, use it for manual exploration instead of writing a temporary repo test.
+- Point ad hoc runs at the repo app you are actually changing: local dev server, `pnpm run start:test`, or an explicitly chosen preview URL.
+- Once a manually reproduced bug becomes clearly repeatable and worth guarding, convert that knowledge into a repo test if the ticket calls for regression coverage.
+
+## Related skills
+- Pair this with `accessibility-audit` when the task centers on keyboard, focus, semantics, or Axe coverage.
+- Pair this with `frontend-ui` when a Playwright failure is rooted in layout or interaction code that still needs implementation work.

--- a/.cursorrules
+++ b/.cursorrules
@@ -53,6 +53,7 @@ Check `.cursor/skills/` for domain-specific guidance:
 - `frontend-ui` — building/refactoring UI components
 - `accessibility-audit` — auditing and improving accessibility
 - `design-review` — reviewing visual hierarchy, spacing, polish
+- `playwright` — repo-specific Playwright setup, test selection, and artifact conventions
 
 ## Definition of Done (per ticket)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Supporting workflow detail lives in [`docs/ai-workflow.md`](docs/ai-workflow.md)
 - Node version: root [`.nvmrc`](.nvmrc)
 - Hosting: Vercel (auto-deploys on merge to `main`)
 - Project board: [GitHub Projects v2](https://github.com/users/tonym999/projects/2) (`tonym999`, project `2`)
-- AI skills: `.cursor/skills/` — frontend-ui, accessibility-audit, design-review
+- AI skills: `.cursor/skills/` — frontend-ui, accessibility-audit, design-review, playwright
 
 ## Workflow
 
@@ -67,6 +67,7 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 - Include a basic accessibility check (axe-core or `page.accessibility.snapshot()`) in at least one critical-path test.
 - Use shared fixtures under `web/tests/e2e/fixtures/` when setup is common across tests.
 - Run the smallest relevant test set first, then broaden if risk justifies it.
+- For repo-specific Playwright setup, command choices, and artifact conventions, read `.cursor/skills/playwright/SKILL.md` instead of duplicating that guidance elsewhere.
 
 ## Implementation Rules
 

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -89,6 +89,7 @@ If `pnpm` prompts Corepack to download a version unexpectedly, confirm the activ
 
 ## Testing — CI Specifics
 
+- Repo-specific Playwright workflow guidance lives in [`.cursor/skills/playwright/SKILL.md`](../.cursor/skills/playwright/SKILL.md). Keep this document focused on policy, CI, and troubleshooting.
 - Run locally: `pnpm run test:e2e:smoke` (from `web/`)
 - Run the cross-device accessibility baseline locally when accessibility-critical UI changes: `pnpm run test:e2e:a11y` (from `web/`)
 - CI: cache Playwright browsers and run `pnpm exec playwright install --with-deps && pnpm run test:e2e:smoke && pnpm run test:e2e:a11y`
@@ -195,5 +196,5 @@ There is no guaranteed sandbox-safe way to always access `gh` for every operatio
 - Read [`AGENTS.md`](../AGENTS.md) first for workflow and rules.
 - Start each new ticket from a freshly updated `main`, not from the last feature branch.
 - Check `.cursorrules` for Cursor-specific behaviour.
-- Check `.cursor/skills/` for domain-specific AI guidance (UI, accessibility, design review).
+- Check `.cursor/skills/` for domain-specific AI guidance (UI, accessibility, design review, Playwright workflow).
 - Review `.cursor/rules/frontend-standards.mdc` for frontend coding standards.


### PR DESCRIPTION
## Summary

Adds a repo-defined `playwright` skill under `.cursor/skills/` so agents can follow the project's Playwright workflow without splitting guidance across generic Codex skills and repo docs. The new skill covers bootstrap steps, when to use repo tests versus ad hoc browser automation, and where to store Playwright artifacts using the repo's existing conventions. `AGENTS.md`, `docs/ai-workflow.md`, and `.cursorrules` now point to the skill instead of duplicating its contents.

## Linked Issue

Closes #109

## Validation Against Issue

This PR adds the requested repo-defined Playwright skill under `.cursor/skills/` and keeps it focused on project-specific workflow rather than generic Playwright documentation. The skill explains `nvm` and Corepack bootstrap, running `pnpm` from `web/`, when to choose existing repo tests versus ad hoc browser automation, and the standard artifact locations already used by the repo (`web/test-results/` and `web/playwright-report/`, plus `web/test-results/manual/` for one-off captures). Repo workflow docs now reference the skill directly so the guidance is discoverable without duplicating the full instructions.

## Changes

- add `.cursor/skills/playwright/SKILL.md` with repo-specific Playwright workflow guidance
- reference the new skill from `AGENTS.md`, `docs/ai-workflow.md`, and `.cursorrules`
- align artifact guidance with the existing ignored Playwright output folders in `web/`

## Testing

- [ ] Not run
- [x] Docs-only / Not applicable
- [ ] `pnpm run lint` (from `web/`)
- [x] `pnpm run test:e2e:smoke` (from `web/`)
- [ ] Other:

## Risks

- User-facing impact: Low. This changes agent workflow guidance only and does not ship runtime behavior changes.
- Rollback plan: Revert this PR to remove the skill and the doc references.

## Screenshots / Evidence

- `pnpm run test:e2e:smoke` passed locally: 20 passed (27.4s)

## Checklist

- [x] The PR is scoped to one main objective
- [x] The linked issue is specific and up to date
- [x] The PR description uses the same terminology as the issue
- [x] Acceptance criteria are covered or explicitly called out as not done
- [x] New docs or workflow changes are reflected in repo documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Playwright skill guide documenting repository setup, test selection, bootstrap procedures, and artifact conventions
  * Updated workflow and testing documentation with new Playwright guidance references

* **Chores**
  * Updated AI skills configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->