### PR TITLE
Add repo-defined environment bootstrap skill

### DIFF
--- a/.cursor/skills/repo-bootstrap/SKILL.md
+++ b/.cursor/skills/repo-bootstrap/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: repo-bootstrap
+description: Bootstrap this repository in a fresh shell or agent session, including loading Node from `.nvmrc`, using Corepack for the pinned `pnpm` version, running package-manager commands from `web/`, validating the environment, and troubleshooting missing pnpm or bootstrap drift.
+---
+
+# Repo Bootstrap
+
+## When to use
+- Starting work in a fresh local shell or Codex session
+- `pnpm` is missing, unexpected, or prompting for Corepack setup
+- A task depends on `web/` commands and you need to confirm the right working directory
+- `.codex/environments/environment.toml`, `.nvmrc`, or `web/package.json` changed and you want to verify the bootstrap still works
+
+## Source of truth
+- Node version: repo-root `.nvmrc`
+- Package manager and version: `web/package.json`
+- Session bootstrap for Codex: `.codex/environments/environment.toml`
+
+## Standard bootstrap flow
+1. From the repo root, load `nvm` and activate the Node version from `.nvmrc`.
+2. Change into `web/` before running package-manager commands so Corepack sees the pinned `pnpm` version from `web/package.json`.
+3. Run `pnpm install` from `web/`.
+4. Run the smallest relevant command for the ticket from `web/` after install.
+
+Example:
+
+```bash
+source "$HOME/.nvm/nvm.sh"
+nvm use
+cd web
+pnpm install
+```
+
+## Verification checklist
+- `command -v node` resolves
+- `node -v` matches the version from `.nvmrc`
+- `cd web && command -v pnpm` resolves
+- `cd web && pnpm -v` runs without falling back to an unexpected global install
+- `cd web && pnpm install` completes without version or engine surprises
+
+## Troubleshooting
+
+### `pnpm` is missing
+- Confirm `nvm use` ran successfully from the repo root instead of another directory.
+- Do not assume `pnpm` lives in `~/.local/share/pnpm`; this repo expects it to come from Corepack through the active Node installation.
+- Re-run from `web/`, because Corepack reads the pinned package manager version from `web/package.json`.
+
+### Corepack prompts for a download unexpectedly
+- Check that the active Node version still matches `.nvmrc`.
+- Confirm you are running `pnpm` from `web/`, not the repo root.
+- On a fresh machine or cache, let Corepack prepare the pinned version once, then retry the command.
+- If this started after bootstrap-related changes, re-check `.codex/environments/environment.toml` for missing `nvm` setup or temp/cache paths.
+
+### Fresh-session bootstrap drift
+- If `.codex/environments/environment.toml` changed, restart Codex before judging the fix.
+- After restart, re-run the verification checklist in a fresh session instead of relying on an older shell.
+- If `node` resolves but `pnpm` behavior changed, compare `.nvmrc`, `web/package.json`, and `.codex/environments/environment.toml` together before changing docs or scripts.
+
+## Practical guardrails
+- Run package-manager, build, lint, and Playwright commands from `web/`.
+- Keep bootstrap documentation aligned across `AGENTS.md` and `docs/ai-workflow.md`; update those when the repo bootstrap changes.
+- Prefer documenting repo-specific surprises in `docs/ai-workflow.md` so future agents can detect them quickly.
+
+## Related files
+- `.nvmrc`
+- `web/package.json`
+- `.codex/environments/environment.toml`
+- `AGENTS.md`
+- `docs/ai-workflow.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Supporting workflow detail lives in [`docs/ai-workflow.md`](docs/ai-workflow.md)
 - Node version: root [`.nvmrc`](.nvmrc)
 - Hosting: Vercel (auto-deploys on merge to `main`)
 - Project board: [GitHub Projects v2](https://github.com/users/tonym999/projects/2) (`tonym999`, project `2`)
-- AI skills: `.cursor/skills/` — frontend-ui, accessibility-audit, design-review, playwright
+- AI skills: `.cursor/skills/` — repo-bootstrap, frontend-ui, accessibility-audit, design-review, playwright
 
 ## Workflow
 
@@ -45,6 +45,7 @@ When creating issues or PRs, use the GitHub templates under `.github/` so linked
 - Run package-manager commands from [`web/`](web/) so Corepack sees the version pinned by the `packageManager` field in [`web/package.json`](web/package.json).
 - A fresh machine or cache may still require Corepack to prepare that pinned version once before offline agent sessions can use it.
 - After changing [`.codex/environments/environment.toml`](.codex/environments/environment.toml), restart Codex and verify a fresh session resolves `node` and `pnpm` before treating the fix as complete.
+- For repo-specific setup, verification, or troubleshooting steps in fresh shells and agent sessions, use [`.cursor/skills/repo-bootstrap/SKILL.md`](.cursor/skills/repo-bootstrap/SKILL.md).
 
 ## Commit Standards
 

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -68,6 +68,8 @@ Use labels intentionally so open issues can be filtered, prioritized, and triage
 
 Use the repo-root [`.nvmrc`](../.nvmrc) to select the project's Node version in fresh shells before running project commands. In this repository, `pnpm` is pinned in [`web/package.json`](../web/package.json) and is typically provided by Corepack through the active `nvm` Node installation rather than a standalone binary in `~/.local/share/pnpm`.
 
+For reusable step-by-step setup and troubleshooting guidance, use [`.cursor/skills/repo-bootstrap/SKILL.md`](../.cursor/skills/repo-bootstrap/SKILL.md). Keep that skill aligned with the repo instructions here and in [`AGENTS.md`](../AGENTS.md).
+
 For Codex sessions, [`.codex/environments/environment.toml`](../.codex/environments/environment.toml) should:
 
 - point temp/cache directories at writable Linux paths
@@ -195,6 +197,7 @@ There is no guaranteed sandbox-safe way to always access `gh` for every operatio
 
 - Read [`AGENTS.md`](../AGENTS.md) first for workflow and rules.
 - Start each new ticket from a freshly updated `main`, not from the last feature branch.
+- Use [`.cursor/skills/repo-bootstrap/SKILL.md`](../.cursor/skills/repo-bootstrap/SKILL.md) when validating a fresh shell, a Codex environment change, or any `pnpm` / Corepack bootstrap issue.
 - Check `.cursorrules` for Cursor-specific behaviour.
 - Check `.cursor/skills/` for domain-specific AI guidance (UI, accessibility, design review, Playwright workflow).
 - Review `.cursor/rules/frontend-standards.mdc` for frontend coding standards.


### PR DESCRIPTION
## Summary

Adds a repo-defined `repo-bootstrap` skill under `.cursor/skills/` for fresh-shell and agent-session setup in this repository. The skill captures the expected `.nvmrc`, Corepack, pinned `pnpm`, `web/` working-directory flow, plus a short verification checklist and troubleshooting guidance. Companion doc updates in `AGENTS.md` and `docs/ai-workflow.md` point back to the skill so the bootstrap guidance stays discoverable without drifting.

## Linked Issue

Closes #111

## Validation Against Issue

This PR adds the requested repo-defined environment bootstrap skill at `.cursor/skills/repo-bootstrap/SKILL.md` and keeps the content focused on repeatable local setup for this repository. The skill explains the `.nvmrc` Node flow, Corepack and the pinned `pnpm` version, makes `web/` the required working directory for package-manager commands, includes a concise fresh-session verification checklist, and documents troubleshooting for missing `pnpm`, unexpected Corepack prompts, and bootstrap drift. `AGENTS.md` and `docs/ai-workflow.md` now reference the skill so the workflow documentation stays aligned.

## Changes

- add `.cursor/skills/repo-bootstrap/SKILL.md` with bootstrap, verification, and troubleshooting guidance
- add `repo-bootstrap` to the documented repo skill list in `AGENTS.md`
- link `AGENTS.md` and `docs/ai-workflow.md` back to the new skill for setup and onboarding guidance

## Testing

- [ ] Not run
- [ ] Docs-only / Not applicable
- [ ] `pnpm run lint` (from `web/`)
- [x] `pnpm run test:e2e:smoke` (from `web/`)
- [ ] Other:

## Risks

- User-facing impact: None expected; changes are limited to repo guidance and AI skill metadata.
- Rollback plan: Revert this PR to remove the new skill and restore the previous docs references.

## Screenshots / Evidence

N/A

## Checklist

- [x] The PR is scoped to one main objective
- [x] The linked issue is specific and up to date
- [x] The PR description uses the same terminology as the issue
- [x] Acceptance criteria are covered or explicitly called out as not done
- [x] New docs or workflow changes are reflected in repo documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced comprehensive repository bootstrap documentation detailing step-by-step setup procedures, Node and package manager configuration sources, environment verification checklist, and troubleshooting guidance for common bootstrap issues.
  * Updated project workflow documentation to cross-reference the new bootstrap guidance, facilitating consistent environment configuration during team onboarding and session initialisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->