### PR TITLE
Add repo-defined CodeRabbit triage skill

### DIFF
--- a/.cursor/skills/coderabbit-triage/SKILL.md
+++ b/.cursor/skills/coderabbit-triage/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: coderabbit-triage
+description: Triage CodeRabbit review feedback for this repo by fetching summary reviews, inline comments, issue comments, and GraphQL review-thread resolution metadata; classify unresolved feedback; and resolve only the threads that were actually addressed.
+---
+
+# CodeRabbit Triage
+
+## When to use
+- A PR in this repo has received CodeRabbit feedback
+- You need to collect all CodeRabbit comments before making follow-up fixes
+- You need to distinguish unresolved versus resolved inline threads
+- You need a repo-specific checklist for which threads to resolve after pushing fixes
+
+## Goal
+Use the same repeatable flow every time:
+1. Fetch all CodeRabbit review surfaces for the PR.
+2. Separate unresolved inline threads from already resolved ones.
+3. Classify unresolved feedback into change requests, nitpicks, and informational items.
+4. Address required items first.
+5. Resolve only the threads that were actually addressed.
+
+## Required data sources
+Collect data from all four sources because no single endpoint contains the whole picture.
+
+### 1. Review summaries
+Use this to capture CodeRabbit's review-level summary entries:
+
+```bash
+gh api --paginate repos/tonym999/patofalltrades/pulls/{PR_NUMBER}/reviews
+```
+
+### 2. Inline review comments
+Use this to capture file and line-specific feedback:
+
+```bash
+gh api --paginate repos/tonym999/patofalltrades/pulls/{PR_NUMBER}/comments
+```
+
+### 3. Issue comments
+Use this to capture top-level PR discussion comments that are not inline review comments:
+
+```bash
+gh api --paginate repos/tonym999/patofalltrades/issues/{PR_NUMBER}/comments
+```
+
+### 4. Review thread resolution metadata
+Use GraphQL `reviewThreads` because the REST review-comment endpoints do not expose `isResolved`:
+
+```bash
+gh api graphql -f query='query {
+  repository(owner: "tonym999", name: "patofalltrades") {
+    pullRequest(number: {PR_NUMBER}) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          path
+          line
+          comments(first: 20) {
+            nodes {
+              id
+              databaseId
+              body
+              author { login }
+              createdAt
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+The example above is intentionally bounded. For unusually large PRs, use cursor pagination or GitHub MCP so additional threads or replies are not missed.
+
+## Triage flow
+
+### 1. Filter to CodeRabbit-authored feedback
+- Keep entries where the author login is `coderabbitai[bot]`.
+- Apply that filter across review summaries, inline comments, issue comments, and GraphQL thread comments.
+
+### 2. Group inline comments into threads
+- Group `/pulls/{PR}/comments` results by `in_reply_to_id`.
+- Treat top-level review summaries from `/pulls/{PR}/reviews` separately because they are not threaded through `in_reply_to_id`.
+- Treat `/issues/{PR}/comments` separately for the same reason.
+
+### 3. Split unresolved and resolved inline threads
+- Match inline comment threads against GraphQL `reviewThreads`.
+- Use `reviewThreads.isResolved` as the source of truth for resolution state.
+- Skip resolved inline threads unless the user explicitly asks for a full audit.
+
+### 4. Summarize each unresolved thread using the latest comment
+- Use the latest comment in the thread as the short summary.
+- Keep earlier comments available for context, especially if the latest message is a reply or clarification.
+- Include file path and line number when the thread is inline.
+
+### 5. Classify unresolved feedback
+Use CodeRabbit's markers when present:
+
+| Class | Markers | Default handling |
+|---|---|---|
+| Change request | `🔧 Actionable:`, `⚠️ Issue:`, `🐛 Bug:`, `🚨 Critical:` | Must address |
+| Nitpick | `💭 Nitpick:`, `📝 Style:` | Address if reasonable |
+| Informational | `💡 Suggestion:`, `✨ Enhancement:` | Optional |
+
+If no marker is present, infer from tone:
+- direct defect or correctness language -> change request
+- minor naming/style wording -> nitpick
+- "consider", "could", or future-looking suggestions -> informational
+
+### 6. Present findings in priority order
+Share results grouped like this:
+1. Change requests
+2. Nitpicks
+3. Informational items
+
+For each item, include:
+- short summary from the latest comment
+- file path and line number when applicable
+- thread URL or enough identifying detail to relocate it quickly
+
+## After fixes
+- Push the follow-up commit(s), for example `fix(scope): address CodeRabbit feedback`.
+- Resolve only the threads that were actually addressed in code or by an intentional documented decision.
+- Leave unresolved threads open if the feedback is still pending, partially addressed, or intentionally deferred.
+- Do not mass-resolve all CodeRabbit threads just because a new commit was pushed.
+
+## Practical notes
+- Review summaries and issue comments do not carry `isResolved`; use them as triage input, not as thread-resolution state.
+- GraphQL thread metadata is the authoritative way to distinguish unresolved from resolved inline feedback in this repo.
+- If a PR is unusually large, prefer paginated GraphQL or GitHub MCP over assuming the `first: 100` and `first: 20` bounds are sufficient.
+
+## Related repo docs
+- `AGENTS.md`
+- `docs/ai-workflow.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Supporting workflow detail lives in [`docs/ai-workflow.md`](docs/ai-workflow.md)
 - Node version: root [`.nvmrc`](.nvmrc)
 - Hosting: Vercel (auto-deploys on merge to `main`)
 - Project board: [GitHub Projects v2](https://github.com/users/tonym999/projects/2) (`tonym999`, project `2`)
-- AI skills: `.cursor/skills/` — repo-bootstrap, frontend-ui, accessibility-audit, design-review, playwright
+- AI skills: `.cursor/skills/` — repo-bootstrap, frontend-ui, accessibility-audit, design-review, playwright, coderabbit-triage
 
 ## Workflow
 
@@ -26,7 +26,7 @@ Supporting workflow detail lives in [`docs/ai-workflow.md`](docs/ai-workflow.md)
 7. Commit with a conventional commit message. Include `Closes #N` when the work completes a ticket.
 8. Push the branch and create a PR scoped to the ticket. Link the PR to the issue.
 9. Keep the issue as the project board item of record. The board automation moves linked issues from `In Progress` to `In Review` when a PR is linked, then to `Done` when that PR is merged. Do not add PRs to the board by default.
-10. After code review (CodeRabbit), triage feedback and address it. See [Code Review Handling](#code-review-handling).
+10. After code review (CodeRabbit), triage feedback and address it. Use [`.cursor/skills/coderabbit-triage/SKILL.md`](.cursor/skills/coderabbit-triage/SKILL.md).
 
 When creating issues or PRs, use the GitHub templates under `.github/` so linked tickets contain the structured context CodeRabbit uses for PR validation.
 
@@ -88,18 +88,14 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ## Code Review Handling
 
-PRs are reviewed by CodeRabbit. After a review is posted:
+PRs are reviewed by CodeRabbit. Use [`.cursor/skills/coderabbit-triage/SKILL.md`](.cursor/skills/coderabbit-triage/SKILL.md) for the repo's exact fetch, classification, and resolution flow.
 
-1. **Fetch** all review threads on the PR.
-2. **Filter** to threads where any comment author is `coderabbitai[bot]`.
-3. **Split** into unresolved and resolved threads using GraphQL `reviewThreads` or GitHub MCP, because the REST comment endpoints do not expose `isResolved`.
-4. **Classify** unresolved threads:
-   - **Change requests** — direct issues, bugs, or required fixes (`🔧`, `⚠️`, `🐛`, `🚨`)
-   - **Nitpicks** — minor style or naming suggestions (`💭`, `📝`)
-   - **Informational** — suggestions or enhancements with no required action (`💡`, `✨`)
-5. **Summarise** each thread using the latest comment, but keep the full thread available for context.
-6. **Address** change requests first, then nitpicks if reasonable. Informational items are optional.
-7. **Push** fixes and resolve threads. Do not resolve threads that haven't been addressed.
+Keep these guardrails in mind:
+
+1. Fetch all CodeRabbit review surfaces before deciding what is unresolved.
+2. Use GraphQL `reviewThreads` resolution metadata, not REST review comments alone, to tell resolved from unresolved inline feedback.
+3. Address change requests first, then nitpicks if reasonable; informational comments are optional.
+4. Resolve only the threads that were actually addressed.
 
 ## Error Handling
 

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -99,53 +99,12 @@ If `pnpm` prompts Corepack to download a version unexpectedly, confirm the activ
 
 ## CodeRabbit Review Integration
 
-The triage workflow is defined in [AGENTS.md — Code Review Handling](../AGENTS.md#code-review-handling). This section covers operational detail.
+Use [`.cursor/skills/coderabbit-triage/SKILL.md`](../.cursor/skills/coderabbit-triage/SKILL.md) for the repo-defined CodeRabbit workflow. That skill is the source of truth for:
 
-### Marker Conventions
-
-CodeRabbit uses emoji markers to classify feedback (not machine-parsed, but useful for triage):
-
-| Priority | Markers | Action |
-|---|---|---|
-| Change request | `🔧 Actionable:`, `⚠️ Issue:`, `🐛 Bug:`, `🚨 Critical:` | Must address |
-| Nitpick | `💭 Nitpick:`, `📝 Style:` | Address if reasonable |
-| Informational | `💡 Suggestion:`, `✨ Enhancement:` | Optional |
-
-### Fetching Review Threads
-
-Use the GitHub API to get all review data:
-
-```bash
-# All reviews (includes CodeRabbit's summary review)
-gh api --paginate repos/tonym999/patofalltrades/pulls/{PR_NUMBER}/reviews
-
-# All inline comments (file-level feedback)
-gh api --paginate repos/tonym999/patofalltrades/pulls/{PR_NUMBER}/comments
-
-# Issue-style comments (top-level summary)
-gh api --paginate repos/tonym999/patofalltrades/issues/{PR_NUMBER}/comments
-
-# Thread resolution metadata
-gh api graphql -f query='query { repository(owner: "tonym999", name: "patofalltrades") { pullRequest(number: {PR_NUMBER}) { reviewThreads(first: 100) { nodes { id isResolved path line comments(first: 20) { nodes { id databaseId body author { login } createdAt url } } } } } } }'
-```
-
-The GraphQL example above is intentionally bounded to the first 100 review threads and the first 20 comments per thread. For unusually large PRs, use cursor pagination or GitHub MCP to avoid missing additional threads or replies.
-
-### Processing Flow
-
-1. Collect all comments from the three REST endpoints above and fetch `reviewThreads` via GraphQL for thread resolution metadata. The example query shown here is a bounded fetch, not full cursor pagination.
-2. Keep only those authored by `coderabbitai[bot]`.
-3. Group inline review comments from `/pulls/{PR}/comments` by `in_reply_to_id`; top-level review summaries from `/pulls/{PR}/reviews` and issue comments from `/issues/{PR}/comments` should be handled separately because they do not use `in_reply_to_id`.
-4. Use GraphQL `reviewThreads.isResolved` to distinguish unresolved and resolved inline threads; resolved threads can be skipped unless the user asks.
-5. Within each unresolved thread, use the latest comment as the primary summary and keep earlier comments for context.
-6. Classify each thread by its markers. If no marker is present, infer from tone: direct instructions are change requests; questions or "consider" phrasing are informational.
-7. Present the remaining items to the user grouped by priority, with file path and line number where applicable.
-
-### After Fixing
-
-- Push fix commits referencing the review (e.g., `fix(scope): address CodeRabbit feedback`).
-- Resolve addressed threads on GitHub, or prompt the user to do so.
-- Do not resolve threads that haven't been addressed — leave them for the next pass.
+- the required REST and GraphQL fetch steps
+- how to separate resolved versus unresolved inline threads
+- how to classify unresolved feedback into change requests, nitpicks, and informational items
+- the rule that only addressed threads should be resolved
 
 ## Troubleshooting
 
@@ -199,5 +158,5 @@ There is no guaranteed sandbox-safe way to always access `gh` for every operatio
 - Start each new ticket from a freshly updated `main`, not from the last feature branch.
 - Use [`.cursor/skills/repo-bootstrap/SKILL.md`](../.cursor/skills/repo-bootstrap/SKILL.md) when validating a fresh shell, a Codex environment change, or any `pnpm` / Corepack bootstrap issue.
 - Check `.cursorrules` for Cursor-specific behaviour.
-- Check `.cursor/skills/` for domain-specific AI guidance (UI, accessibility, design review, Playwright workflow).
+- Check `.cursor/skills/` for domain-specific AI guidance (UI, accessibility, design review, Playwright workflow, CodeRabbit triage).
 - Review `.cursor/rules/frontend-standards.mdc` for frontend coding standards.


### PR DESCRIPTION
## Summary

Add a repo-defined CodeRabbit triage skill under `.cursor/skills/` and update the repo docs to reference that skill instead of duplicating the workflow.

## Linked Issue

Closes #110

## Validation Against Issue

This PR adds `.cursor/skills/coderabbit-triage/SKILL.md` with the repo-specific fetch, classification, and resolution workflow for CodeRabbit feedback. It documents review summaries, inline comments, issue comments, and GraphQL `reviewThreads` metadata, explains the change request/nitpick/informational classification rules, and reinforces that only addressed threads should be resolved. `AGENTS.md` and `docs/ai-workflow.md` now reference the skill so the workflow is not duplicated across repo docs.

## Changes

- add the `coderabbit-triage` repo skill under `.cursor/skills/`
- list the new skill in `AGENTS.md` and point CodeRabbit handling to it
- replace the duplicated CodeRabbit operational detail in `docs/ai-workflow.md` with a reference to the skill

## Testing

- [ ] Not run
- [x] Docs-only / Not applicable
- [ ] `pnpm run lint` (from `web/`)
- [ ] `pnpm run test:e2e:smoke` (from `web/`)
- [ ] Other:

## Risks

- User-facing impact: none; docs and agent workflow guidance only
- Rollback plan: revert this PR to remove the skill and restore the prior docs

## Screenshots / Evidence

N/A

## Checklist

- [x] The PR is scoped to one main objective
- [x] The linked issue is specific and up to date
- [x] The PR description uses the same terminology as the issue
- [x] Acceptance criteria are covered or explicitly called out as not done
- [x] New docs or workflow changes are reflected in repo documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to reference a centralised triage skill guide.
  * Consolidated CodeRabbit review integration guidance into a single source of truth.
  * Refined documentation structure for improved clarity on feedback triage and classification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->